### PR TITLE
feat(prompt sizes): Update model info

### DIFF
--- a/src/common/llm/promptLength.ts
+++ b/src/common/llm/promptLength.ts
@@ -2,7 +2,15 @@ import { logger } from '../utils/logger'
 
 export const modelInfo = [
   {
+    model: 'openai:o3',
+    maxPromptLength: 300000, //100k tokens
+  },
+  {
     model: 'openai:o3-mini',
+    maxPromptLength: 300000, //100k tokens
+  },
+  {
+    model: 'openai:o4-mini',
     maxPromptLength: 300000, //100k tokens
   },
   {
@@ -16,6 +24,18 @@ export const modelInfo = [
   {
     model: 'openai:gpt-4o',
     maxPromptLength: 300000, //128k tokens
+  },
+  {
+    model: 'openai:gpt-4.1',
+    maxPromptLength: 2400000, //1024k tokens (1M context window)
+  },
+  {
+    model: 'openai:gpt-4.1-mini',
+    maxPromptLength: 2400000, //1024k tokens (1M context window)
+  },
+  {
+    model: 'openai:gpt-4.1-nano',
+    maxPromptLength: 2400000, //1024k tokens (1M context window)
   },
   {
     model: 'openai:gpt-4-turbo',
@@ -35,7 +55,7 @@ export const modelInfo = [
   },
   {
     model: 'openai:gpt-3.5-turbo',
-    maxPromptLength: 9000, //4k tokens
+    maxPromptLength: 45000, //16k tokens
   },
   {
     model: 'openai:gpt-3.5-turbo-16k',


### PR DESCRIPTION
Summary from GitHub Copilot:

> This pull request updates the `modelInfo` array in `src/common/llm/promptLength.ts` to add support for new models, adjust context window sizes, and modify existing prompt length limits. Below is a summary of the most important changes:
> 
> ### Additions of new models:
> * Added entries for new models `openai:o3`, `openai:o4-mini`, `openai:gpt-4.1`, `openai:gpt-4.1-mini`, and `openai:gpt-4.1-nano` with their respective `maxPromptLength` values. (`[[1]](diffhunk://#diff-07ac2872c510af9da98ef4d56be6122b18d30ef79ae1dc7c0f5303cdc87f3b48R4-R15)`, `[[2]](diffhunk://#diff-07ac2872c510af9da98ef4d56be6122b18d30ef79ae1dc7c0f5303cdc87f3b48R28-R39)`)
> 
> ### Adjustments to existing models:
> * Increased the `maxPromptLength` for `openai:gpt-3.5-turbo` from 9000 tokens to 45000 tokens, reflecting an expanded context window. (`[src/common/llm/promptLength.tsL38-R58](diffhunk://#diff-07ac2872c510af9da98ef4d56be6122b18d30ef79ae1dc7c0f5303cdc87f3b48L38-R58)`)