### PR TITLE
Add Github Models support

### DIFF
--- a/docs/ai-provider-config.md
+++ b/docs/ai-provider-config.md
@@ -1,6 +1,6 @@
 # Provider Configuration
 
-Shippie support OpenAI, Anthropic, Google Gemini and local models through an OpenAI compatible API.
+Shippie supports OpenAI, Anthropic, Google Gemini, GitHub Models, and local models through an OpenAI compatible API.
 
 Just change the `modelString` to the model you want to use.
 
@@ -9,6 +9,26 @@ eg.
 ```yaml
 - name: Run shippie review
   run: bun review --platform=github --modelString=azure:gpt-4o
+```
+
+## GitHub Models
+
+GitHub Models provides free access to AI models directly in GitHub Actions using the built-in `GITHUB_TOKEN`. This is the easiest setup option as it requires no additional API keys or secrets.
+
+### Usage
+
+When configuring shippie with `npx shippie configure --platform=github`, choose the GitHub Models option for automatic setup.
+
+Or manually configure your workflow:
+
+```yaml
+- name: Run shippie review
+  run: bun shippie review --platform=github --modelString=openai:gpt-4o-mini --baseUrl=https://models.github.ai/inference
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    GITHUB_SHA: ${{ github.sha }}
+    OPENAI_API_KEY: ${{ secrets.GITHUB_TOKEN }}  # GitHub Models uses GITHUB_TOKEN as API key
 ```
 
 ## Azure OpenAI Provider

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -16,7 +16,11 @@ In the root of your git repository run:
 npx shippie configure --platform=github
 ```
 
-The setup script automatically adds an `OPENAI_API_KEY` secret to your repo. More info on secrets can be found [here](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+The setup script will ask for your OpenAI API key. You can:
+1. **Leave it blank** - Uses GitHub Models (free) with the built-in `GITHUB_TOKEN` to access GitHub's AI models at `https://models.github.ai/inference`
+2. **Provide an OpenAI API key** - Uses OpenAI's API and automatically adds the `OPENAI_API_KEY` secret to your repo
+
+More info on GitHub Actions secrets can be found [here](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 
 See [templates](https://github.com/mattzcarey/shippie/tree/main/templates) for the example yaml files. You can copy and paste them to perform a manual setup or have a look at the [action configuration options](https://github.com/mattzcarey/shippie/tree/main/docs/action-options.md).
 
@@ -35,9 +39,9 @@ Shippie supports a bunch of setup options. This is a work in progress so check o
 
 - Review Language - The language you want to review the code in.
 - Platform - The platform you are using eg. github, gitlab, azure devops, local.
-- Model String - The model you want to use eg. openai:gpt-4o, azure:gpt-4o, anthropic:claude-3-5-sonnet-20240620.
+- Model String - The model you want to use eg. openai:gpt-4o, azure:gpt-4o, anthropic:claude-3-5-sonnet-20240620. When using GitHub platform with GitHub Models, use openai:gpt-4o-mini with baseUrl=https://models.github.ai/inference.
 - (optional) Max Steps - The maximum number of steps the bot will take. defaults to 25.
-- (optional) Base URL - The base URL for the AI provider. You can change this to use OpenAI compatible providers like DeepSeek or local models with LM Studio or Ollama.
+- (optional) Base URL - The base URL for the AI provider. Use https://models.github.ai/inference for GitHub Models, or change this to use OpenAI compatible providers like DeepSeek or local models with LM Studio or Ollama.
 - (optional) Ignore - A list of globs to ignore when reviewing the code. Defaults to `dist/**, node_modules/**, **/*.d.ts, **/*.lock, **/package-lock.json`.
 - (optional) Telemetry - Toggle anonymous telemetry. Defaults to True
 - (optional) Debug - Toggle debug logging. Defaults to False.

--- a/src/configure/index.ts
+++ b/src/configure/index.ts
@@ -19,7 +19,21 @@ export const configure = async (yargs: ConfigureArgs): Promise<void> => {
   }
 }
 
-const captureApiKey = async (): Promise<string | undefined> => {
+const captureGitHubApiKey = async (): Promise<string | undefined> => {
+  const apiKey = await password({
+    message: 'Please input your OpenAI API key (leave blank to use GitHub Models):',
+    mask: '*',
+  })
+
+  if (!apiKey) {
+    logger.info('No API key provided, using GitHub Models.')
+    return undefined
+  }
+
+  return apiKey
+}
+
+const captureApiKey = async (): Promise<string> => {
   const apiKey = await password({
     message: 'Please input your OpenAI API key:',
   })
@@ -28,7 +42,11 @@ const captureApiKey = async (): Promise<string | undefined> => {
 }
 
 const configureGitHub = async () => {
-  const githubWorkflowTemplate = await findTemplateFile('**/templates/github-pr.yml')
+  const apiKey = await captureGitHubApiKey()
+
+  // Choose template based on whether we're using GitHub Models or OpenAI
+  const templateName = apiKey ? 'github-pr.yml' : 'github-pr-models.yml'
+  const githubWorkflowTemplate = await findTemplateFile(`**/templates/${templateName}`)
 
   const workflowsDir = path.join(process.cwd(), '.github', 'workflows')
   fs.mkdirSync(workflowsDir, { recursive: true })
@@ -38,24 +56,16 @@ const configureGitHub = async () => {
 
   logger.info(`Created GitHub Actions workflow at: ${workflowFile}`)
 
-  const apiKey = await captureApiKey()
-
-  if (!apiKey) {
-    logger.error(
-      'No API key provided. Please manually add the OPENAI_API_KEY secret to your GitHub repository.'
-    )
-
-    return
-  }
-
-  try {
-    execSync('gh auth status || gh auth login', { stdio: 'inherit' })
-    execSync(`gh secret set OPENAI_API_KEY --body=${String(apiKey)}`)
-    logger.info('Successfully added the OPENAI_API_KEY secret to your GitHub repository.')
-  } catch (error) {
-    logger.error(
-      "It seems that the GitHub CLI is not installed or there was an error during authentication. Don't forget to add the OPENAI_API_KEY to the repo settings/Environment/Actions/Repository Secrets manually."
-    )
+  if (apiKey) {
+    try {
+      execSync('gh auth status || gh auth login', { stdio: 'inherit' })
+      execSync(`gh secret set OPENAI_API_KEY --body=${String(apiKey)}`)
+      logger.info('Successfully added the OPENAI_API_KEY secret to your GitHub repository.')
+    } catch (error) {
+      logger.error(
+        "It seems that the GitHub CLI is not installed or there was an error during authentication. Don't forget to add the OPENAI_API_KEY to the repo settings/Environment/Actions/Repository Secrets manually."
+      )
+    }
   }
 }
 

--- a/templates/github-pr-models.yml
+++ b/templates/github-pr-models.yml
@@ -1,0 +1,34 @@
+name: Shippie 🚢
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: read
+  models: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install shippie
+        run: bun i shippie
+
+      - name: Run shippie review
+        run: bun shippie review --platform=github --modelString=openai:gpt-4o-mini --baseUrl=https://models.github.ai/inference
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_SHA: ${{ github.sha }}
+          OPENAI_API_KEY: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds support for [GitHub Models](https://docs.github.com/en/github-models/use-github-models/integrating-ai-models-into-your-development-workflow#using-ai-models-with-github-actions), which is GitHub's free inference API (free to all users, no secret needed in GitHub Actions).

If you use the GitHub Models inference URL, you don't need an OPENAI_API_KEY or any separate secret at all. I think it's cool to let people get code reviews without having to go and pay for an OpenAI subscription.

I figured the most straightforward approach was to default to Models when OPENAI_API_KEY is blank, but happy to make any changes you request!