### PR TITLE
feat: add support for root-level rules files and deduplication

### DIFF
--- a/docs/rules-files.md
+++ b/docs/rules-files.md
@@ -14,6 +14,14 @@ Rules files help the AI reviewer understand your project's:
 
 These files are automatically discovered from standard locations and intelligently incorporated into the review prompt.
 
+## Rule Deduplication
+
+Shippie automatically deduplicates rules to avoid redundancy:
+
+- **Content-based**: Rules with identical content are automatically merged
+- **Description-based**: Rules with very similar descriptions are deduplicated
+- **Path preference**: When duplicates are found, more specific paths (e.g., `.cursor/rules/`) are preferred over root-level files
+
 ## Supported Directories
 
 Shippie searches for rules files in these directories:
@@ -21,8 +29,19 @@ Shippie searches for rules files in these directories:
 ```
 .cursor/rules/          # Cursor editor rules
 .shippie/rules/         # Shippie-specific rules
-.windsurfrules/         # Windsurf editor rules
+.windsurfrules/         # Windsurf editor rules (legacy)
+.windsurf/rules/        # Windsurf editor rules (preferred)
 clinerules/             # CLI-specific rules
+```
+
+## Root-Level Rules Files
+
+Additionally, these files in the project root are treated as rules files:
+
+```
+AGENTS.md               # AI agent instructions
+AGENT.md                # Alternative agent instructions  
+CLAUDE.md               # Claude-specific instructions
 ```
 
 ## Supported File Types
@@ -154,11 +173,8 @@ Keep components small and focused.
 
 ## Important Documentation Files
 
-Additionally, these files are automatically included in full if they exist:
+Additionally, these files are automatically included as documentation context if they exist:
 
-- `AGENTS.md` - AI agent instructions
-- `AGENT.md` - Alternative agent instructions
-- `CLAUDE.md` - Claude-specific instructions
 - `todo.md` - Project todos
 - `.same/todos.md` - Alternative todos location
 - `CONTRIBUTING.md` - Contribution guidelines
@@ -171,10 +187,14 @@ my-project/
 │   ├── typescript.mdc      # TS style rules
 │   ├── security.mdc        # Security requirements (alwaysApply: true)
 │   └── react.md           # React best practices
+├── .windsurf/rules/
+│   └── windsurf-specific.mdc # Windsurf editor rules
 ├── .shippie/rules/
 │   └── architecture.mdc    # Architecture patterns
-├── CLAUDE.md              # AI instructions
-├── CONTRIBUTING.md        # Contribution guide
+├── AGENTS.md              # AI agent instructions (rules file)
+├── CLAUDE.md              # Claude-specific instructions (rules file)
+├── CONTRIBUTING.md        # Contribution guide (documentation)
+├── todo.md                # Project todos (documentation)
 └── src/
     └── components/
 ```

--- a/src/review/utils/rulesFiles.ts
+++ b/src/review/utils/rulesFiles.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { join, relative } from 'node:path'
+import { createHash } from 'node:crypto'
 import matter from 'gray-matter'
 import { glob } from 'tinyglobby'
 import { logger } from '../../common/utils/logger'
@@ -27,14 +28,15 @@ const RULES_DIRECTORIES = [
   '.cursor/rules/*.{mdc,md}',
   '.shippie/rules/*.{mdc,md}',
   '.windsurfrules/*.{mdc,md}',
+  '.windsurf/rules/*.{mdc,md}',
   'clinerules/*.{mdc,md}',
+  'AGENTS.md',
+  'AGENT.md',
+  'CLAUDE.md',
 ]
 
 const IMPORTANT_FILES = [
-  'AGENTS.md',
-  'AGENT.md',
   'todo.md',
-  'CLAUDE.md',
   '.same/todos.md',
   'CONTRIBUTING.md',
 ]
@@ -59,6 +61,56 @@ const parseGlobs = (globs: unknown): string[] | undefined => {
   }
 
   return undefined
+}
+
+const generateContentHash = (content: string): string => {
+  return createHash('sha256').update(content.trim()).digest('hex').slice(0, 16)
+}
+
+const deduplicateRules = (rules: RuleFile[]): RuleFile[] => {
+  const seen = new Set<string>()
+  const seenDescriptions = new Map<string, RuleFile>()
+  const deduplicated: RuleFile[] = []
+
+  for (const rule of rules) {
+    const contentHash = generateContentHash(rule.content)
+    
+    // Skip if we've seen this exact content before
+    if (seen.has(contentHash)) {
+      logger.debug(`Skipping duplicate rule content from ${rule.path}`)
+      continue
+    }
+    
+    // Check for very similar descriptions (likely duplicates)
+    const normalizedDesc = rule.description.toLowerCase().trim()
+    const existingRule = seenDescriptions.get(normalizedDesc)
+    
+    if (existingRule) {
+      // Keep the rule with more specific path (prefer specific directories over root files)
+      const currentSpecificity = rule.path.split('/').length
+      const existingSpecificity = existingRule.path.split('/').length
+      
+      if (currentSpecificity > existingSpecificity) {
+        // Replace the existing rule with the more specific one
+        const existingIndex = deduplicated.findIndex(r => r.path === existingRule.path)
+        if (existingIndex !== -1) {
+          deduplicated[existingIndex] = rule
+          seenDescriptions.set(normalizedDesc, rule)
+          logger.debug(`Replacing rule from ${existingRule.path} with more specific rule from ${rule.path}`)
+        }
+      } else {
+        logger.debug(`Skipping rule from ${rule.path}, already have similar rule from ${existingRule.path}`)
+        continue
+      }
+    } else {
+      seenDescriptions.set(normalizedDesc, rule)
+      deduplicated.push(rule)
+    }
+    
+    seen.add(contentHash)
+  }
+
+  return deduplicated
 }
 
 export const findRulesFiles = async (workspaceRoot: string): Promise<RuleFile[]> => {
@@ -101,7 +153,7 @@ export const findRulesFiles = async (workspaceRoot: string): Promise<RuleFile[]>
     }
   }
 
-  return rulesFiles
+  return deduplicateRules(rulesFiles)
 }
 
 export const findImportantFiles = async (

--- a/src/review/utils/specs/rulesFiles.test.ts
+++ b/src/review/utils/specs/rulesFiles.test.ts
@@ -138,28 +138,27 @@ Keep components small and focused.`
     const workspace = await createTempWorkspace()
 
     try {
-      const agentsContent = `# AI Agents Guide
+      const todoContent = `# Todo List
 
-This project uses AI agents for code review.
-Please follow these guidelines when working with agents.`
+- Fix bugs
+- Add features`
 
-      const claudeContent = `# Claude Instructions
+      const contributingContent = `# Contributing Guide
 
-Use concise responses.
-Focus on code quality.`
+Please follow these guidelines when contributing.`
 
-      await writeFile(join(workspace, 'AGENTS.md'), agentsContent)
-      await writeFile(join(workspace, 'CLAUDE.md'), claudeContent)
+      await writeFile(join(workspace, 'todo.md'), todoContent)
+      await writeFile(join(workspace, 'CONTRIBUTING.md'), contributingContent)
 
       const importantFiles = await findImportantFiles(workspace)
 
       expect(importantFiles).toHaveLength(2)
 
-      const agentsFile = importantFiles.find((f) => f.path === 'AGENTS.md')
-      const claudeFile = importantFiles.find((f) => f.path === 'CLAUDE.md')
+      const todoFile = importantFiles.find((f) => f.path === 'todo.md')
+      const contributingFile = importantFiles.find((f) => f.path === 'CONTRIBUTING.md')
 
-      expect(agentsFile?.content).toBe(agentsContent)
-      expect(claudeFile?.content).toBe(claudeContent)
+      expect(todoFile?.content).toBe(todoContent)
+      expect(contributingFile?.content).toBe(contributingContent)
     } finally {
       await cleanupTempWorkspace(workspace)
     }
@@ -255,5 +254,144 @@ Focus on code quality.`
   test('formatRulesContext returns empty string when no files found', () => {
     const context = formatRulesContext([], [])
     expect(context).toBe('')
+  })
+
+  test('findRulesFiles finds root-level rule files (AGENTS.md, AGENT.md, CLAUDE.md)', async () => {
+    const workspace = await createTempWorkspace()
+
+    try {
+      const agentsContent = `---
+description: AI Agents Guidelines
+globs: ["**/*.ts", "**/*.js"]
+alwaysApply: true
+---
+# AI Agents Guidelines
+
+Use AI agents responsibly.`
+
+      const agentContent = `# Agent Configuration
+
+This file contains agent-specific rules.`
+
+      const claudeContent = `---
+description: Claude Instructions
+---
+# Claude Instructions
+
+Be concise and helpful.`
+
+      await writeFile(join(workspace, 'AGENTS.md'), agentsContent)
+      await writeFile(join(workspace, 'AGENT.md'), agentContent)
+      await writeFile(join(workspace, 'CLAUDE.md'), claudeContent)
+
+      const rulesFiles = await findRulesFiles(workspace)
+
+      expect(rulesFiles).toHaveLength(3)
+
+      const agentsFile = rulesFiles.find((f) => f.path === 'AGENTS.md')
+      const agentFile = rulesFiles.find((f) => f.path === 'AGENT.md')
+      const claudeFile = rulesFiles.find((f) => f.path === 'CLAUDE.md')
+
+      expect(agentsFile?.type).toBe('md')
+      expect(agentsFile?.description).toBe('AI Agents Guidelines')
+      expect(agentsFile?.frontmatter?.alwaysApply).toBe(true)
+      expect(agentsFile?.frontmatter?.globs).toEqual(['**/*.ts', '**/*.js'])
+
+      expect(agentFile?.type).toBe('md')
+      expect(agentFile?.description).toContain('Agent Configuration')
+      expect(agentFile?.frontmatter).toBeUndefined()
+
+      expect(claudeFile?.type).toBe('md')
+      expect(claudeFile?.description).toBe('Claude Instructions')
+      expect(claudeFile?.frontmatter?.alwaysApply).toBeUndefined()
+    } finally {
+      await cleanupTempWorkspace(workspace)
+    }
+  })
+
+  test('findRulesFiles deduplicates rules by content hash', async () => {
+    const workspace = await createTempWorkspace()
+
+    try {
+      await mkdir(join(workspace, '.cursor', 'rules'), { recursive: true })
+
+      const duplicateContent = `# React Guidelines
+
+Always use functional components.`
+
+      // Create two files with identical content
+      await writeFile(join(workspace, '.cursor', 'rules', 'react1.md'), duplicateContent)
+      await writeFile(join(workspace, '.cursor', 'rules', 'react2.md'), duplicateContent)
+
+      const rulesFiles = await findRulesFiles(workspace)
+
+      // Should only return one rule due to deduplication
+      expect(rulesFiles).toHaveLength(1)
+      expect(rulesFiles[0].content.trim()).toBe(duplicateContent.trim())
+    } finally {
+      await cleanupTempWorkspace(workspace)
+    }
+  })
+
+  test('findRulesFiles deduplicates rules by similar descriptions, preferring more specific paths', async () => {
+    const workspace = await createTempWorkspace()
+
+    try {
+      await mkdir(join(workspace, '.cursor', 'rules'), { recursive: true })
+
+      const rootContent = `---
+description: React Guidelines
+---
+# React Guidelines
+
+Root level react rules.`
+
+      const specificContent = `---
+description: React Guidelines  
+---
+# React Guidelines
+
+More specific react rules from cursor directory.`
+
+      // Create files with same description but different specificity
+      await writeFile(join(workspace, 'AGENTS.md'), rootContent)
+      await writeFile(join(workspace, '.cursor', 'rules', 'react.md'), specificContent)
+
+      const rulesFiles = await findRulesFiles(workspace)
+
+      // Should keep the more specific one (.cursor/rules/react.md)
+      expect(rulesFiles).toHaveLength(1)
+      expect(rulesFiles[0].path).toBe('.cursor/rules/react.md')
+      expect(rulesFiles[0].content.trim()).toContain('More specific react rules')
+    } finally {
+      await cleanupTempWorkspace(workspace)
+    }
+  })
+
+  test('findImportantFiles no longer includes AGENTS.md, AGENT.md, CLAUDE.md', async () => {
+    const workspace = await createTempWorkspace()
+
+    try {
+      const agentsContent = `# AI Agents Guide`
+      const claudeContent = `# Claude Instructions`
+      const todoContent = `# Todo List`
+
+      await writeFile(join(workspace, 'AGENTS.md'), agentsContent)
+      await writeFile(join(workspace, 'CLAUDE.md'), claudeContent)
+      await writeFile(join(workspace, 'todo.md'), todoContent)
+
+      const importantFiles = await findImportantFiles(workspace)
+
+      // Should only include todo.md, not the agent/claude files
+      expect(importantFiles).toHaveLength(1)
+      expect(importantFiles[0].path).toBe('todo.md')
+
+      // Verify these files are now handled as rules files instead
+      const rulesFiles = await findRulesFiles(workspace)
+      expect(rulesFiles.some(f => f.path === 'AGENTS.md')).toBe(true)
+      expect(rulesFiles.some(f => f.path === 'CLAUDE.md')).toBe(true)
+    } finally {
+      await cleanupTempWorkspace(workspace)
+    }
   })
 })


### PR DESCRIPTION
Add support for root-level rules files (AGENTS.md, AGENT.md, CLAUDE.md) and implement intelligent rule deduplication.

## Changes
- Add AGENTS.md, AGENT.md, and CLAUDE.md as rules files
- Remove these files from IMPORTANT_FILES to avoid duplication
- Implement content-based and description-based rule deduplication
- Preserve existing .windsurf/rules/ support from previous work
- Add comprehensive test coverage for new functionality
- Update documentation to reflect changes

## Deduplication Logic
- Content-based: Rules with identical content are automatically merged
- Description-based: Rules with very similar descriptions are deduplicated
- Path preference: More specific paths (e.g. .cursor/rules/) are preferred over root-level files

Resolves #454

🤖 Generated with [Claude Code](https://claude.ai/code)