### PR TITLE
fix: pin @flue/* to exact 1.0.0-beta.1 so npx install boots

### DIFF
--- a/.changeset/pin-flue-versions.md
+++ b/.changeset/pin-flue-versions.md
@@ -1,0 +1,5 @@
+---
+"shippie": patch
+---
+
+Fix `shippie review` crashing on a clean install with `[flue] Agent "mention" must default-export createAgent(...)`. The `@flue/*` dependencies were ranged with a caret (`^1.0.0-beta.1`), so installs floated to `@flue/runtime@1.0.0-beta.3`, whose `createAgent` marker (`__flueAgentDefinition`) no longer matches the validator bundled into `dist/server.mjs` (built against `beta.1`'s `__flueCreatedAgent`). Pin `@flue/runtime`, `@flue/github`, and `@flue/cli` to exact `1.0.0-beta.1` so the runtime installed by `npx`/the GitHub Action always matches the bundled build output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "shippie",
-    "version": "0.21.0",
+    "version": "0.21.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "shippie",
-            "version": "0.21.0",
+            "version": "0.21.1",
             "license": "MIT",
             "dependencies": {
-                "@flue/github": "^1.0.0-beta.1",
-                "@flue/runtime": "^1.0.0-beta.1",
+                "@flue/github": "1.0.0-beta.1",
+                "@flue/runtime": "1.0.0-beta.1",
                 "octokit": "^3.1.0",
                 "picomatch": "^4.0.2",
                 "valibot": "^1.4.1"
@@ -22,7 +22,7 @@
                 "@biomejs/biome": "^1.9.4",
                 "@changesets/changelog-github": "^0.7.0",
                 "@changesets/cli": "^2.31.0",
-                "@flue/cli": "^1.0.0-beta.1",
+                "@flue/cli": "1.0.0-beta.1",
                 "@types/node": "^22.10.0",
                 "@types/picomatch": "^4.0.0",
                 "typescript": "^5.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,13 +141,13 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.974.21",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.21.tgz",
-            "integrity": "sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==",
+            "version": "3.974.23",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+            "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "^3.973.13",
-                "@aws-sdk/xml-builder": "^3.972.30",
+                "@aws-sdk/xml-builder": "^3.972.31",
                 "@aws/lambda-invoke-store": "^0.2.2",
                 "@smithy/core": "^3.24.6",
                 "@smithy/signature-v4": "^5.4.6",
@@ -160,12 +160,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.972.47",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.47.tgz",
-            "integrity": "sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==",
+            "version": "3.972.49",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+            "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.21",
+                "@aws-sdk/core": "^3.974.23",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
                 "@smithy/types": "^4.14.3",
@@ -176,12 +176,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.972.49",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.49.tgz",
-            "integrity": "sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==",
+            "version": "3.972.51",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+            "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.21",
+                "@aws-sdk/core": "^3.974.23",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
                 "@smithy/fetch-http-handler": "^5.4.6",
@@ -194,12 +194,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.0.tgz",
-            "integrity": "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+            "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.25.0",
+                "@smithy/core": "^3.26.0",
                 "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
@@ -208,19 +208,19 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.972.54",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.54.tgz",
-            "integrity": "sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==",
+            "version": "3.972.56",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+            "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.21",
-                "@aws-sdk/credential-provider-env": "^3.972.47",
-                "@aws-sdk/credential-provider-http": "^3.972.49",
-                "@aws-sdk/credential-provider-login": "^3.972.53",
-                "@aws-sdk/credential-provider-process": "^3.972.47",
-                "@aws-sdk/credential-provider-sso": "^3.972.53",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.53",
-                "@aws-sdk/nested-clients": "^3.997.21",
+                "@aws-sdk/core": "^3.974.23",
+                "@aws-sdk/credential-provider-env": "^3.972.49",
+                "@aws-sdk/credential-provider-http": "^3.972.51",
+                "@aws-sdk/credential-provider-login": "^3.972.55",
+                "@aws-sdk/credential-provider-process": "^3.972.49",
+                "@aws-sdk/credential-provider-sso": "^3.972.55",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+                "@aws-sdk/nested-clients": "^3.997.23",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
                 "@smithy/credential-provider-imds": "^4.3.7",
@@ -232,13 +232,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.972.53",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.53.tgz",
-            "integrity": "sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==",
+            "version": "3.972.55",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+            "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.21",
-                "@aws-sdk/nested-clients": "^3.997.21",
+                "@aws-sdk/core": "^3.974.23",
+                "@aws-sdk/nested-clients": "^3.997.23",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
                 "@smithy/types": "^4.14.3",
@@ -249,17 +249,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.972.56",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.56.tgz",
-            "integrity": "sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==",
+            "version": "3.972.58",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+            "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "^3.972.47",
-                "@aws-sdk/credential-provider-http": "^3.972.49",
-                "@aws-sdk/credential-provider-ini": "^3.972.54",
-                "@aws-sdk/credential-provider-process": "^3.972.47",
-                "@aws-sdk/credential-provider-sso": "^3.972.53",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.53",
+                "@aws-sdk/credential-provider-env": "^3.972.49",
+                "@aws-sdk/credential-provider-http": "^3.972.51",
+                "@aws-sdk/credential-provider-ini": "^3.972.56",
+                "@aws-sdk/credential-provider-process": "^3.972.49",
+                "@aws-sdk/credential-provider-sso": "^3.972.55",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.55",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
                 "@smithy/credential-provider-imds": "^4.3.7",
@@ -271,12 +271,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.972.47",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.47.tgz",
-            "integrity": "sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==",
+            "version": "3.972.49",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+            "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.21",
+                "@aws-sdk/core": "^3.974.23",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
                 "@smithy/types": "^4.14.3",
@@ -287,14 +287,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.972.53",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.53.tgz",
-            "integrity": "sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==",
+            "version": "3.972.55",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+            "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.21",
-                "@aws-sdk/nested-clients": "^3.997.21",
-                "@aws-sdk/token-providers": "3.1069.0",
+                "@aws-sdk/core": "^3.974.23",
+                "@aws-sdk/nested-clients": "^3.997.23",
+                "@aws-sdk/token-providers": "3.1074.0",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
                 "@smithy/types": "^4.14.3",
@@ -305,13 +305,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-            "version": "3.1069.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1069.0.tgz",
-            "integrity": "sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==",
+            "version": "3.1074.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+            "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.21",
-                "@aws-sdk/nested-clients": "^3.997.21",
+                "@aws-sdk/core": "^3.974.23",
+                "@aws-sdk/nested-clients": "^3.997.23",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
                 "@smithy/types": "^4.14.3",
@@ -322,13 +322,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.972.53",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.53.tgz",
-            "integrity": "sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==",
+            "version": "3.972.55",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+            "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.21",
-                "@aws-sdk/nested-clients": "^3.997.21",
+                "@aws-sdk/core": "^3.974.23",
+                "@aws-sdk/nested-clients": "^3.997.23",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
                 "@smithy/types": "^4.14.3",
@@ -369,12 +369,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-websocket": {
-            "version": "3.972.29",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.29.tgz",
-            "integrity": "sha512-Agv95NCgYyvuYUXt2PcFcOMrKCkhBFPhoH+nVMQh85RcXSCQrhAa4475plBOeomCihP26vKHT5KinVQT3iD14w==",
+            "version": "3.972.31",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.31.tgz",
+            "integrity": "sha512-ps1rumU1LybSFHaW9dTDgkhCMJLVaedEY78kKSzUDDY+b9974/g6aiaYYA0U9WV0oL4CJCJrVWG+EZ/qr4or7g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.21",
+                "@aws-sdk/core": "^3.974.23",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
                 "@smithy/fetch-http-handler": "^5.4.6",
@@ -387,14 +387,14 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.997.21",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.21.tgz",
-            "integrity": "sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==",
+            "version": "3.997.23",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+            "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.974.21",
+                "@aws-sdk/core": "^3.974.23",
                 "@aws-sdk/signature-v4-multi-region": "^3.996.35",
                 "@aws-sdk/types": "^3.973.13",
                 "@smithy/core": "^3.24.6",
@@ -408,12 +408,12 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.0.tgz",
-            "integrity": "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+            "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.25.0",
+                "@smithy/core": "^3.26.0",
                 "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
@@ -479,13 +479,12 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.972.30",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
-            "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
+            "version": "3.972.31",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+            "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.14.3",
-                "fast-xml-parser": "5.7.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1133,12 +1132,12 @@
             }
         },
         "node_modules/@earendil-works/pi-agent-core": {
-            "version": "0.79.6",
-            "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.6.tgz",
-            "integrity": "sha512-SXZc4rQI+3zgUmAJDbU0GzFEHCPHbhItjN7QLsahj3TKfQAon4guwCqsrwZBLH5lPcub2+evTojPNrPItL62tA==",
+            "version": "0.79.10",
+            "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.10.tgz",
+            "integrity": "sha512-XKxgdjhcPuyjrthCOFSgfzT3xZ1uBrJ1IMVDxci1to6hIN6BIg9J5iY8q0pGXK1DLgATLP23da+1UyZLwA360Q==",
             "license": "MIT",
             "dependencies": {
-                "@earendil-works/pi-ai": "^0.79.6",
+                "@earendil-works/pi-ai": "^0.79.10",
                 "ignore": "7.0.5",
                 "typebox": "1.1.38",
                 "yaml": "2.9.0"
@@ -1148,15 +1147,16 @@
             }
         },
         "node_modules/@earendil-works/pi-ai": {
-            "version": "0.79.6",
-            "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.6.tgz",
-            "integrity": "sha512-KGepEdgEeWDs7Imwlp96tBsO8TjSIpcDBvazsCDtHRa81+uwJI/YGetTegI52pMlKhVpJFLIGajRi4PCGC5MUg==",
+            "version": "0.79.10",
+            "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.10.tgz",
+            "integrity": "sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew==",
             "license": "MIT",
             "dependencies": {
                 "@anthropic-ai/sdk": "0.91.1",
                 "@aws-sdk/client-bedrock-runtime": "3.1048.0",
                 "@google/genai": "1.52.0",
-                "@mistralai/mistralai": "2.2.1",
+                "@mistralai/mistralai": "2.2.6",
+                "@opentelemetry/api": "1.9.0",
                 "@smithy/node-http-handler": "4.7.3",
                 "http-proxy-agent": "7.0.2",
                 "https-proxy-agent": "7.0.6",
@@ -1722,9 +1722,9 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.5.tgz",
-            "integrity": "sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.6.tgz",
+            "integrity": "sha512-7DeRlKG57JDBNZ5Qj2jwVdgwQy4b0tLubRLl3zCf91/rCf9i7p1V5FtW/yWibm1uUHE493ts9ZXH/7g/LQWl+g==",
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -2406,14 +2406,23 @@
             "license": "MIT"
         },
         "node_modules/@mistralai/mistralai": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-            "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+            "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
             "license": "Apache-2.0",
             "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.40.0",
                 "ws": "^8.18.0",
                 "zod": "^3.25.0 || ^4.0.0",
                 "zod-to-json-schema": "^3.25.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.9.0"
+            },
+            "peerDependenciesMeta": {
+                "@opentelemetry/api": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@mixmark-io/domino": {
@@ -2427,7 +2436,6 @@
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
             "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@hono/node-server": "^1.19.9",
                 "ajv": "^8.17.1",
@@ -2967,6 +2975,25 @@
             "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
             "integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
             "license": "MIT"
+        },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.41.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+            "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/@oxc-project/types": {
             "version": "0.133.0",
@@ -3726,9 +3753,9 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.25.0",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.0.tgz",
-            "integrity": "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A==",
+            "version": "3.26.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+            "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/crc32": "5.2.0",
@@ -3740,12 +3767,12 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.0.tgz",
-            "integrity": "sha512-pPQmNdEvMJttv9z2kdYxoui83p/nr32zjMf0aMfmzmGmFEgKXUfy0vXiNg0fx4R5XLQzmJBLM9Wg0guEq2/q8A==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+            "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.25.0",
+                "@smithy/core": "^3.26.0",
                 "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
@@ -3754,12 +3781,12 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.0.tgz",
-            "integrity": "sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA==",
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+            "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.25.0",
+                "@smithy/core": "^3.26.0",
                 "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
@@ -3794,12 +3821,12 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.0.tgz",
-            "integrity": "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg==",
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+            "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.25.0",
+                "@smithy/core": "^3.26.0",
                 "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
@@ -4260,9 +4287,9 @@
             }
         },
         "node_modules/anynum": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-            "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
             "funding": [
                 {
                     "type": "github",
@@ -4914,6 +4941,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -5160,9 +5188,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-            "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+            "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
             "funding": [
                 {
                     "type": "github",
@@ -5171,10 +5199,12 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@nodable/entities": "^2.1.0",
-                "fast-xml-builder": "^1.1.7",
+                "@nodable/entities": "^2.2.0",
+                "fast-xml-builder": "^1.2.0",
+                "is-unsafe": "^1.0.1",
                 "path-expression-matcher": "^1.5.0",
-                "strnum": "^2.2.3"
+                "strnum": "^2.4.1",
+                "xml-naming": "^0.1.0"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -5798,6 +5828,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/is-unsafe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+            "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -5919,9 +5961,9 @@
             }
         },
         "node_modules/just-bash": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/just-bash/-/just-bash-3.0.1.tgz",
-            "integrity": "sha512-YVyzCN08fKarUnwqy7rKOAcX+2MLYLnYInuowmUXn3mqhrtd4ieZNBuzdQG+qYV9DqnIWuv9Whiph0WRIWsBtw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/just-bash/-/just-bash-3.0.2.tgz",
+            "integrity": "sha512-uY8LMD2NpADp1HlYUcZSw9ffuq0tRhW76sg8xkeo+ZRDMu7mbekWbKbYDWquazVVi7pqpGZlic/liMFktQKy6w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "diff": "^8.0.2",
@@ -6863,9 +6905,9 @@
             }
         },
         "node_modules/papaparse": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
-            "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.4.tgz",
+            "integrity": "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==",
             "license": "MIT"
         },
         "node_modules/parseurl": {
@@ -6894,9 +6936,9 @@
             }
         },
         "node_modules/path-expression-matcher": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+            "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
             "funding": [
                 {
                     "type": "github",
@@ -7781,9 +7823,9 @@
             }
         },
         "node_modules/smol-toml": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+            "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">= 18"
@@ -7905,9 +7947,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-            "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
             "funding": [
                 {
                     "type": "github",
@@ -7916,7 +7958,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "anynum": "^1.0.0"
+                "anynum": "^1.0.1"
             }
         },
         "node_modules/strtok3": {

--- a/package.json
+++ b/package.json
@@ -72,8 +72,5 @@
         "hono": "^4.12.26",
         "esbuild": "^0.28.1"
     },
-    "files": [
-        "dist",
-        "bin"
-    ]
+    "files": ["dist", "bin"]
 }

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
         "node": ">=22.19.0"
     },
     "dependencies": {
-        "@flue/github": "^1.0.0-beta.1",
-        "@flue/runtime": "^1.0.0-beta.1",
+        "@flue/github": "1.0.0-beta.1",
+        "@flue/runtime": "1.0.0-beta.1",
         "octokit": "^3.1.0",
         "picomatch": "^4.0.2",
         "valibot": "^1.4.1"
@@ -62,7 +62,7 @@
         "@biomejs/biome": "^1.9.4",
         "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.31.0",
-        "@flue/cli": "^1.0.0-beta.1",
+        "@flue/cli": "1.0.0-beta.1",
         "@types/node": "^22.10.0",
         "@types/picomatch": "^4.0.0",
         "typescript": "^5.1.6",


### PR DESCRIPTION
## Problem

`npx shippie@0.21.1 review` crashes at boot on a clean install:

```
Error: [flue] Agent "mention" must default-export createAgent(...).
```

CI never caught it because the GitHub Action's `flue run review` lazily loads only the review agent, whereas the **published** `dist/server.mjs` (booted by the `shippie` CLI) eagerly validates **every** agent module at startup.

## Root cause

The `@flue/*` deps were ranged `^1.0.0-beta.1`. Per semver, that caret matches `1.0.0-beta.3`, so fresh installs floated the externalized `@flue/runtime` to **beta.3** — whose `createAgent` returns `{ __flueAgentDefinition }` instead of beta.1's `{ __flueCreatedAgent: true }`. The validator **bundled into `dist/server.mjs`** (from `@flue/cli@beta.1`) still checks for `__flueCreatedAgent` → throws.

| | marker on the agent object |
|---|---|
| `@flue/runtime@1.0.0-beta.1` (built against) | `__flueCreatedAgent: true` ✅ |
| `@flue/runtime@1.0.0-beta.3` (floated to) | `__flueAgentDefinition` ❌ |

## Fix

Pin `@flue/runtime`, `@flue/github`, and `@flue/cli` to **exact `1.0.0-beta.1`** so the runtime installed by `npx`/the Action always matches the validator bundled at build time.

## Verification

Packed the tarball and installed it **fresh** (resolving `@flue/*` from npm via the new pins). `@flue/runtime@1.0.0-beta.1` resolved, the server booted, and `shippie review` returned:

```json
{ "reviewed": 0, "summaryPosted": false, "message": "No changed files to review." }
```

Local gates: biome ✅ · tsc ✅ · 73 tests ✅ · build ✅