### PR TITLE
refactor: move tests out of src into top-level tests/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ anywhere flue deploys (Node, Cloudflare, GitHub Actions, GitLab CI).
 - `src/agents/reviewer.ts` — the review agent (`createAgent`): model, `local()` sandbox, instructions, and the `suggest_change` tool.
 - `src/workflows/review.ts` — the one-shot review workflow (`run({ init, payload, env })`); also exports `route` so the built server can serve `POST /workflows/review`.
 - `src/tools/suggest-change.ts` — `defineTool` for inline review comments.
-- `src/review/` — `config.ts` (resolve config from payload/env), `diff.ts` (git diff + parsing), `instructions.ts` (review prompt + AGENTS.md/CLAUDE.md injection), `context.ts` (prompt builder), `constants.ts`, `prompt/fileInfo.ts`, `utils/filterFiles.ts`, `specs/*` (tests).
+- `src/review/` — `config.ts` (resolve config from payload/env), `diff.ts` (git diff + parsing), `instructions.ts` (review prompt + AGENTS.md/CLAUDE.md injection), `context.ts` (prompt builder), `constants.ts`, `prompt/fileInfo.ts`, `utils/filterFiles.ts`.
+- `tests/` — vitest specs (`*.test.ts`), mirroring the `src/` layout (kept out of `src/` so the package code stays clean).
 - `src/github/reporter.ts` — posts inline comments + summary to GitHub (Octokit) or to a local file.
 - `src/mcp/connect.ts` — connects remote MCP servers from config.
 - `src/common/` — shared `types.ts` and `formatting/summary.ts`.

--- a/tests/agents/agents.test.ts
+++ b/tests/agents/agents.test.ts
@@ -29,9 +29,9 @@ const { mockClient } = vi.hoisted(() => {
 // Never touch the real GitHub API.
 vi.mock('octokit', () => ({ Octokit: vi.fn(() => mockClient) }))
 
-import { channel } from '../../channels/github'
-import mention from '../mention'
-import reviewer from '../reviewer'
+import { channel } from '../../src/channels/github'
+import mention from '../../src/agents/mention'
+import reviewer from '../../src/agents/reviewer'
 
 const toolNames = (tools: unknown): string[] =>
   Array.isArray(tools)

--- a/tests/channels/github.test.ts
+++ b/tests/channels/github.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { channel, commentOnIssue, getPullRequestDiff } from '../github'
+import { channel, commentOnIssue, getPullRequestDiff } from '../../src/channels/github'
 
 // `vi.hoisted` runs before the (hoisted) static imports, so the webhook secret
 // is set before the channel module loads as a live channel rather than the

--- a/tests/common/telemetry.test.ts
+++ b/tests/common/telemetry.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { type TelemetryInput, sendReviewStarted } from '../telemetry'
+import { type TelemetryInput, sendReviewStarted } from '../../src/common/telemetry'
 
 const TELEMETRY_URL = 'https://telemetry.shippie.dev/events'
 

--- a/tests/github/reporter.test.ts
+++ b/tests/github/reporter.test.ts
@@ -2,8 +2,8 @@ import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { FORMATTING } from '../../common/formatting/summary'
-import type { ReviewConfig } from '../../review/config'
+import { FORMATTING } from '../../src/common/formatting/summary'
+import type { ReviewConfig } from '../../src/review/config'
 
 const mockClient = {
   rest: {
@@ -27,7 +27,7 @@ const mockClient = {
 
 vi.mock('octokit', () => ({ Octokit: vi.fn(() => mockClient) }))
 
-import { createReporter } from '../reporter'
+import { createReporter } from '../../src/github/reporter'
 
 const baseGithubConfig = (workspace: string): ReviewConfig => ({
   platform: 'github',

--- a/tests/mcp/connect.test.ts
+++ b/tests/mcp/connect.test.ts
@@ -1,7 +1,7 @@
 import type { ToolDefinition } from '@flue/runtime'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { McpServerInput } from '../../review/config'
-import { connectMcpServers } from '../connect'
+import type { McpServerInput } from '../../src/review/config'
+import { connectMcpServers } from '../../src/mcp/connect'
 
 const { connectMcpServer } = vi.hoisted(() => ({ connectMcpServer: vi.fn() }))
 

--- a/tests/review/config.test.ts
+++ b/tests/review/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { resolveReviewConfig } from '../config'
+import { resolveReviewConfig } from '../../src/review/config'
 
 const env = (e: Record<string, string>) => e as unknown as NodeJS.ProcessEnv
 

--- a/tests/review/context.test.ts
+++ b/tests/review/context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { buildReviewPrompt } from '../context'
-import type { ReviewFileWithDiff } from '../diff'
+import { buildReviewPrompt } from '../../src/review/context'
+import type { ReviewFileWithDiff } from '../../src/review/diff'
 
 const WS = '/repo'
 

--- a/tests/review/diff.test.ts
+++ b/tests/review/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
-import type { ReviewConfig } from '../config'
-import { buildDiffArgs, parseDiff } from '../diff'
+import type { ReviewConfig } from '../../src/review/config'
+import { buildDiffArgs, parseDiff } from '../../src/review/diff'
 
 const WS = '/repo'
 

--- a/tests/review/instructions.test.ts
+++ b/tests/review/instructions.test.ts
@@ -2,8 +2,8 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
-import type { ReviewConfig } from '../config'
-import { buildInstructions } from '../instructions'
+import type { ReviewConfig } from '../../src/review/config'
+import { buildInstructions } from '../../src/review/instructions'
 
 const makeConfig = (
   workspace: string,

--- a/tests/review/utils/filterFiles.test.ts
+++ b/tests/review/utils/filterFiles.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
-import type { ReviewFile } from '../../../common/types'
-import { filterFiles } from '../filterFiles'
+import type { ReviewFile } from '../../../src/common/types'
+import { filterFiles } from '../../../src/review/utils/filterFiles'
 
 describe('filterFiles unit test', () => {
   test('uses default ignored globs when no globs provided', () => {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createReporter } from '../github/reporter'
-import type { ReviewConfig } from '../review/config'
-import * as reviewWorkflow from '../workflows/review'
+import { createReporter } from '../src/github/reporter'
+import type { ReviewConfig } from '../src/review/config'
+import * as reviewWorkflow from '../src/workflows/review'
 
 /**
  * Smoke / load-time crash tests.
@@ -54,19 +54,19 @@ describe('smoke: modules load without crashing when secrets are absent', () => {
   })
 
   it('imports the reviewer agent without throwing', async () => {
-    await expect(import('../agents/reviewer')).resolves.toBeDefined()
+    await expect(import('../src/agents/reviewer')).resolves.toBeDefined()
   })
 
   it('imports the review workflow without throwing', async () => {
-    await expect(import('../workflows/review')).resolves.toBeDefined()
+    await expect(import('../src/workflows/review')).resolves.toBeDefined()
   })
 
   it('imports the github channel without throwing (webhook secret unset)', async () => {
-    await expect(import('../channels/github')).resolves.toBeDefined()
+    await expect(import('../src/channels/github')).resolves.toBeDefined()
   })
 
   it('imports the mention agent without throwing', async () => {
-    await expect(import('../agents/mention')).resolves.toBeDefined()
+    await expect(import('../src/agents/mention')).resolves.toBeDefined()
   })
 })
 

--- a/tests/tools/suggest-change.test.ts
+++ b/tests/tools/suggest-change.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Reporter } from '../../github/reporter'
-import { createSuggestChangeTool } from '../suggest-change'
+import type { Reporter } from '../../src/github/reporter'
+import { createSuggestChangeTool } from '../../src/tools/suggest-change'
 
 const makeReporter = (postReviewComment: Reporter['postReviewComment']): Reporter => ({
   postReviewComment,

--- a/tests/workflows/review.test.ts
+++ b/tests/workflows/review.test.ts
@@ -3,25 +3,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // Mock only the collaborators that touch git, GitHub, or MCP transports.
 // `filterFiles` and `resolveReviewConfig` are exercised for real.
 const getChangedFiles = vi.fn()
-vi.mock('../../review/diff', async (orig) => ({
-  ...(await orig<typeof import('../../review/diff')>()),
+vi.mock('../../src/review/diff', async (orig) => ({
+  ...(await orig<typeof import('../../src/review/diff')>()),
   getChangedFiles: (...args: unknown[]) => getChangedFiles(...args),
 }))
 
 const postSummary = vi.fn().mockResolvedValue('http://s')
 const postReviewComment = vi.fn()
 const createReporter = vi.fn(() => ({ postSummary, postReviewComment }))
-vi.mock('../../github/reporter', () => ({
+vi.mock('../../src/github/reporter', () => ({
   createReporter: (...args: unknown[]) => createReporter(...args),
 }))
 
 const mcpClose = vi.fn().mockResolvedValue(undefined)
 const connectMcpServers = vi.fn().mockResolvedValue({ tools: [], close: mcpClose })
-vi.mock('../../mcp/connect', () => ({
+vi.mock('../../src/mcp/connect', () => ({
   connectMcpServers: (...args: unknown[]) => connectMcpServers(...args),
 }))
 
-import { run } from '../review'
+import { run } from '../../src/workflows/review'
 
 const PAYLOAD = { platform: 'local' as const, workspace: process.cwd(), ignore: [] }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['tests/**/*.test.ts'],
     environment: 'node',
   },
 })


### PR DESCRIPTION
Moves all 13 vitest specs from `src/**/specs/*.test.ts` into a top-level **`tests/`** directory that mirrors the `src/` layout (the per-module `specs/` segment is dropped).

## Why
Keeps `src/` as pure package code — tests no longer live inside the source tree.

## What changed
- 13 `*.test.ts` files moved (git tracks them as renames). E.g. `src/review/specs/diff.test.ts` → `tests/review/diff.test.ts`, `src/specs/smoke.test.ts` → `tests/smoke.test.ts`.
- Relative imports + `vi.mock()` + dynamic `import()` specifiers recomputed via real path resolution (now `../src/...` / `../../src/...`).
- `vitest.config.ts`: `include` → `tests/**/*.test.ts`.
- Removed empty `specs/` dirs; updated AGENTS.md structure notes.

## Verification
73 tests ✅ (13 files) · `tsc --noEmit` ✅ · `npm run check` (oxlint+oxfmt, now covering `tests/`) ✅ · `flue build` ✅

No changeset — no change to the published package (`files` is `dist`+`bin`; tests were never published).