### PR TITLE
style(www): biome format landing components

### DIFF
--- a/apps/www/src/components/AgentFeatures.tsx
+++ b/apps/www/src/components/AgentFeatures.tsx
@@ -109,7 +109,9 @@ const AgentFeatures = () => {
                         )}
                       />
                       <div>
-                        <span className="text-sm text-foreground/90">{feature.title}</span>
+                        <span className="text-sm text-foreground/90">
+                          {feature.title}
+                        </span>
                         {feature.description && (
                           <p className="mt-1 text-xs text-muted-foreground">
                             {feature.description}

--- a/apps/www/src/components/FaqAccordion.tsx
+++ b/apps/www/src/components/FaqAccordion.tsx
@@ -63,7 +63,9 @@ const FaqAccordion = () => {
                 className="rounded border bg-primary-foreground px-4"
                 value="item-4"
               >
-                <AccordionTrigger>Can I extend Shippie with my own tools?</AccordionTrigger>
+                <AccordionTrigger>
+                  Can I extend Shippie with my own tools?
+                </AccordionTrigger>
                 <AccordionContent className="text-muted-foreground">
                   Yes. Shippie acts as a Model Context Protocol (MCP) client, so you can
                   connect external tools — browser automation, observability, or

--- a/apps/www/src/components/Footer.tsx
+++ b/apps/www/src/components/Footer.tsx
@@ -11,11 +11,7 @@ const Footer = () => {
         <div className="flex flex-col gap-8 py-12 md:flex-row md:items-center md:justify-between">
           <div className="flex flex-col gap-3">
             <a href="/" className="flex items-center gap-2">
-              <Rocket
-                size={24}
-                weight="fill"
-                className="text-black dark:text-white"
-              />
+              <Rocket size={24} weight="fill" className="text-black dark:text-white" />
               <span className="font-medium text-black dark:text-white">Shippie</span>
             </a>
             <p className="max-w-xs text-sm text-muted-foreground">
@@ -58,9 +54,7 @@ const Footer = () => {
         </div>
 
         <div className="border-t border-gray-200 py-6 text-sm text-muted-foreground dark:border-neutral-800">
-          <p>
-            © {new Date().getFullYear()} Shippie · Open source under the MIT license.
-          </p>
+          <p>© {new Date().getFullYear()} Shippie · Open source under the MIT license.</p>
         </div>
       </div>
     </footer>

--- a/apps/www/src/components/Hero.tsx
+++ b/apps/www/src/components/Hero.tsx
@@ -1,5 +1,5 @@
-import { motion } from 'framer-motion'
 import { GithubLogo } from '@phosphor-icons/react'
+import { motion } from 'framer-motion'
 import { useEffect, useMemo, useState } from 'react'
 import { ShellCommand } from './ShellCommand'
 import { Button } from './ui/button'
@@ -34,12 +34,7 @@ const Hero = () => {
       <div className="container mx-auto">
         <div className="flex gap-8 py-20 pb-12 lg:py-32 lg:pb-16 items-center justify-center flex-col">
           <div>
-            <Button
-              variant="secondary"
-              size="sm"
-              className="gap-2"
-              asChild
-            >
+            <Button variant="secondary" size="sm" className="gap-2" asChild>
               <a href={GITHUB_REPO} target="_blank" rel="noopener noreferrer">
                 <GithubLogo size={16} weight="fill" /> Open source on GitHub
               </a>


### PR DESCRIPTION
Runs biome's formatter + import-sort over the `apps/www` landing components — fixes formatting drift from the recent copy cleanup and design polish (the apps' biome isn't run by the root CI, so this wasn't auto-caught). No behavior change; `tsc -b` + `vite build` green.