### PR TITLE
feat(www): redesign landing site (Freight Inspection)

### DIFF
--- a/apps/www/index.html
+++ b/apps/www/index.html
@@ -4,8 +4,14 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Saira+Condensed:wght@500;600;700;800;900&family=Archivo:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <link href="/src/styles.css" rel="stylesheet">
-    <title>Shippie — an extendable AI code review agent</title>
+    <title>Shippie — the AI code reviewer that clears your code to merge</title>
     <meta
       name="description"
       content="Shippie is an open-source, extendable AI code review agent. It runs on your pull requests or locally, posts focused inline review comments, and catches bugs, secrets, and missing tests."

--- a/apps/www/src/components/AgentFeatures.tsx
+++ b/apps/www/src/components/AgentFeatures.tsx
@@ -3,48 +3,45 @@ import { useEffect, useState } from 'react'
 import { cn } from '../lib/utils'
 import { ShellCommand } from './ShellCommand'
 
-interface AgentFeature {
-  title: string
-  description?: string
-}
-
 interface Agent {
   name: string
+  code: string
   description: string
-  features: AgentFeature[]
-  highlighted?: boolean
+  features: string[]
 }
 
 const agentFeatures: Agent[] = [
   {
     name: 'Reviews on GitHub',
+    code: 'CI',
     description:
-      'Shippie runs as a GitHub Action on your pull requests. It reads the diff and posts focused inline comments plus a summary, just like a human reviewer.',
+      'Runs as a GitHub Action on every pull request. Reads the diff and posts focused inline comments plus a summary — like a human reviewer, minus the wait.',
     features: [
-      { title: 'Catches exposed secrets and potential bugs' },
-      { title: 'Flags slow or inefficient code and unhandled edge cases' },
-      { title: 'Points out missing tests' },
+      'Catches exposed secrets and bugs',
+      'Flags slow code and edge cases',
+      'Points out missing tests',
     ],
   },
   {
     name: 'Explores your codebase',
+    code: 'AGENT',
     description:
-      'Built on the flue agent framework, Shippie runs an agent loop with real developer tools — so it reads beyond the diff to understand the full picture.',
+      'Built on the flue agent framework, Shippie runs a real agent loop with developer tools — so it reads far beyond the diff to understand the full picture.',
     features: [
-      { title: 'Navigates files and follows references, not just the diff' },
-      { title: 'Provider-agnostic: Anthropic, OpenAI, OpenRouter, Cloudflare' },
-      { title: 'Open source and extendable to fit your workflow' },
+      'Follows references, not just the diff',
+      'Anthropic · OpenAI · OpenRouter · Cloudflare',
+      'Open source and extendable',
     ],
-    highlighted: true,
   },
   {
     name: 'Extend it with MCP',
+    code: 'MCP',
     description:
-      'Shippie acts as a Model Context Protocol (MCP) client, so you can connect external tools and give the agent more context during a review.',
+      'Acts as a Model Context Protocol client, so you can wire in external tools and give the agent more context while it reviews.',
     features: [
-      { title: 'Browser automation to QA web apps' },
-      { title: 'Observability and documentation servers' },
-      { title: 'Bring your own MCP servers' },
+      'Browser automation to QA web apps',
+      'Observability and docs servers',
+      'Bring your own MCP servers',
     ],
   },
 ]
@@ -56,96 +53,107 @@ const AgentFeatures = () => {
     const interval = setInterval(() => {
       setActiveIndex((current) => (current + 1) % agentFeatures.length)
     }, 3000)
-
     return () => clearInterval(interval)
   }, [])
 
   return (
-    <div id="agent" className="w-full">
-      <div className="container mx-auto">
-        <div className="flex gap-8 py-20 lg:py-32 items-center justify-center flex-col">
-          <div className="flex gap-4 flex-col">
-            <h2 className="text-3xl md:text-4xl font-bold tracking-tighter text-center">
+    <section id="agent" className="w-full border-t border-border/60">
+      <div className="container mx-auto px-6">
+        <div className="flex flex-col items-center py-24 lg:py-32">
+          <div className="flex flex-col items-center text-center">
+            <span className="mb-5 font-mono text-[11px] uppercase tracking-[0.3em] text-signal">
+              The inspection
+            </span>
+            <h2 className="max-w-3xl font-display text-[clamp(2.25rem,5vw,3.75rem)] font-extrabold uppercase leading-[0.92] tracking-tight">
               A reviewer that reads the whole picture
             </h2>
-            <p className="text-lg leading-relaxed tracking-tight text-muted-foreground max-w-2xl text-center mx-auto">
-              Shippie does the read-through a human reviewer would, on every change you
+            <p className="mt-5 max-w-xl text-balance text-muted-foreground">
+              Shippie does the read-through a human reviewer would — on every change you
               ship.
             </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto mt-8">
-            {agentFeatures.map((agentFeature, index) => (
+          <div className="mt-16 grid w-full max-w-6xl grid-cols-1 gap-px overflow-hidden border border-border bg-border md:grid-cols-3">
+            {agentFeatures.map((agent, index) => (
               <div
-                key={agentFeature.name}
+                key={agent.name}
                 className={cn(
-                  'flex flex-col overflow-hidden rounded-2xl border bg-card/40 backdrop-blur transition-all duration-500',
-                  activeIndex === index
-                    ? 'border-red-500/50 shadow-xl shadow-red-500/10 ring-1 ring-red-500/20'
-                    : 'border-border hover:border-white/20 hover:bg-card/60'
+                  'group relative flex flex-col bg-card p-8 transition-colors duration-500',
+                  activeIndex === index ? 'bg-card' : 'hover:bg-secondary/60'
                 )}
               >
-                <div className="flex-1 p-8">
-                  <h3 className="mb-3 text-xl font-semibold tracking-tight">
-                    {agentFeature.name}
-                  </h3>
-                  <p className="text-sm leading-relaxed text-muted-foreground">
-                    {agentFeature.description}
-                  </p>
+                {/* active marker rail */}
+                <span
+                  className={cn(
+                    'absolute left-0 top-0 h-full w-[3px] transition-colors duration-500',
+                    activeIndex === index ? 'bg-signal' : 'bg-transparent'
+                  )}
+                />
+
+                <div className="mb-6 flex items-baseline justify-between">
+                  <span className="font-display text-5xl font-extrabold leading-none text-muted-foreground/25">
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <span
+                    className={cn(
+                      'border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] transition-colors duration-500',
+                      activeIndex === index
+                        ? 'border-signal/50 text-signal'
+                        : 'border-border text-muted-foreground'
+                    )}
+                  >
+                    {agent.code}
+                  </span>
                 </div>
 
-                <div className="space-y-3 border-t border-border bg-muted/20 p-8">
-                  <h4 className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground/80">
-                    Highlights
-                  </h4>
+                <h3 className="font-display text-2xl font-bold uppercase tracking-tight">
+                  {agent.name}
+                </h3>
+                <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
+                  {agent.description}
+                </p>
 
-                  {agentFeature.features.map((feature) => (
-                    <div key={feature.title} className="flex items-start gap-3">
+                <ul className="mt-7 space-y-2.5 border-t border-border pt-6">
+                  {agent.features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-2.5">
                       <Check
                         weight="bold"
                         className={cn(
-                          'mt-0.5 h-4 w-4 flex-shrink-0 transition-colors',
-                          activeIndex === index ? 'text-red-400' : 'text-emerald-400/80'
+                          'mt-0.5 h-3.5 w-3.5 flex-shrink-0 transition-colors duration-500',
+                          activeIndex === index
+                            ? 'text-signal'
+                            : 'text-muted-foreground/60'
                         )}
                       />
-                      <div>
-                        <span className="text-sm text-foreground/90">
-                          {feature.title}
-                        </span>
-                        {feature.description && (
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            {feature.description}
-                          </p>
-                        )}
-                      </div>
-                    </div>
+                      <span className="font-mono text-xs leading-relaxed text-foreground/80">
+                        {feature}
+                      </span>
+                    </li>
                   ))}
-                </div>
+                </ul>
               </div>
             ))}
           </div>
 
           <div
             id="install"
-            className="flex flex-col items-center gap-4 mt-8 w-full max-w-xl"
+            className="mt-20 flex w-full max-w-xl flex-col items-center gap-4"
           >
-            <h3 className="text-2xl font-bold tracking-tighter text-center">
-              Get started in seconds
+            <h3 className="font-display text-3xl font-extrabold uppercase tracking-tight">
+              Cleared in seconds
             </h3>
-            <p className="text-muted-foreground text-center">
-              Scaffold the GitHub Action workflow, then add your provider API key as a
-              repo secret.
+            <p className="text-center text-muted-foreground">
+              Scaffold the GitHub Action, add your provider key as a repo secret, ship.
             </p>
             <ShellCommand command="npx shippie init" />
-            <p className="text-sm text-muted-foreground text-center">
-              Prefer to try it locally first? Run{' '}
-              <code className="font-mono text-foreground">npx shippie review</code> to
-              review your staged changes.
+            <p className="text-center font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground/70">
+              Or run <span className="text-foreground/80">npx shippie review</span> on
+              your staged changes
             </p>
           </div>
         </div>
       </div>
-    </div>
+    </section>
   )
 }
 

--- a/apps/www/src/components/CustomLogo.tsx
+++ b/apps/www/src/components/CustomLogo.tsx
@@ -1,4 +1,4 @@
-import { Rocket } from '@phosphor-icons/react'
+import { Anchor } from '@phosphor-icons/react'
 import { cn } from '../lib/utils'
 
 interface CustomLogoProps {
@@ -9,13 +9,12 @@ const CustomLogo = ({ className }: CustomLogoProps) => {
   return (
     <a
       href="/"
-      className={cn(
-        'relative z-20 mr-4 flex items-center space-x-2 px-2 py-1 text-sm font-normal',
-        className
-      )}
+      className={cn('relative z-20 mr-4 flex items-center gap-2 px-2 py-1', className)}
     >
-      <Rocket size={30} weight="fill" className="text-black dark:text-white" />
-      <span className="font-medium text-black dark:text-white">Shippie</span>
+      <Anchor size={22} weight="bold" className="text-signal" />
+      <span className="font-display text-xl font-extrabold uppercase tracking-tight text-foreground">
+        Shippie
+      </span>
     </a>
   )
 }

--- a/apps/www/src/components/FaqAccordion.tsx
+++ b/apps/www/src/components/FaqAccordion.tsx
@@ -7,22 +7,22 @@ import {
 
 const FaqAccordion = () => {
   return (
-    <div id="faq" className="w-full">
-      <div className="container mx-auto">
-        <div className="flex gap-8 py-20 lg:py-32 items-center justify-center flex-col">
-          <div className="flex gap-4 flex-col">
-            <h2 className="text-3xl md:text-4xl font-bold tracking-tighter text-center">
-              Frequently Asked Questions
+    <div id="faq" className="w-full border-t border-border/60">
+      <div className="container mx-auto px-6">
+        <div className="flex gap-8 py-24 lg:py-32 items-center justify-center flex-col">
+          <div className="flex flex-col items-center text-center">
+            <span className="mb-5 font-mono text-[11px] uppercase tracking-[0.3em] text-signal">
+              The fine print
+            </span>
+            <h2 className="font-display text-[clamp(2.25rem,5vw,3.75rem)] font-extrabold uppercase leading-[0.92] tracking-tight">
+              Questions, answered
             </h2>
-            <p className="text-lg leading-relaxed tracking-tight text-muted-foreground max-w-2xl text-center mx-auto">
-              Find answers to common questions about Shippie
-            </p>
           </div>
 
-          <div className="w-full max-w-3xl mx-auto mt-8">
-            <Accordion type="single" collapsible className="w-full space-y-4 text-sm">
+          <div className="w-full max-w-3xl mx-auto mt-6">
+            <Accordion type="single" collapsible className="w-full space-y-3 text-sm">
               <AccordionItem
-                className="rounded border bg-primary-foreground px-4"
+                className="border border-border bg-card/40 px-5 transition-colors hover:border-border/80"
                 value="item-1"
               >
                 <AccordionTrigger>What is Shippie?</AccordionTrigger>
@@ -35,7 +35,7 @@ const FaqAccordion = () => {
                 </AccordionContent>
               </AccordionItem>
               <AccordionItem
-                className="rounded border bg-primary-foreground px-4"
+                className="border border-border bg-card/40 px-5 transition-colors hover:border-border/80"
                 value="item-2"
               >
                 <AccordionTrigger>How do I run it?</AccordionTrigger>
@@ -49,7 +49,7 @@ const FaqAccordion = () => {
                 </AccordionContent>
               </AccordionItem>
               <AccordionItem
-                className="rounded border bg-primary-foreground px-4"
+                className="border border-border bg-card/40 px-5 transition-colors hover:border-border/80"
                 value="item-3"
               >
                 <AccordionTrigger>Which AI providers does it support?</AccordionTrigger>
@@ -60,7 +60,7 @@ const FaqAccordion = () => {
                 </AccordionContent>
               </AccordionItem>
               <AccordionItem
-                className="rounded border bg-primary-foreground px-4"
+                className="border border-border bg-card/40 px-5 transition-colors hover:border-border/80"
                 value="item-4"
               >
                 <AccordionTrigger>
@@ -73,7 +73,7 @@ const FaqAccordion = () => {
                 </AccordionContent>
               </AccordionItem>
               <AccordionItem
-                className="rounded border bg-primary-foreground px-4"
+                className="border border-border bg-card/40 px-5 transition-colors hover:border-border/80"
                 value="item-5"
               >
                 <AccordionTrigger>Is Shippie open source?</AccordionTrigger>

--- a/apps/www/src/components/Footer.tsx
+++ b/apps/www/src/components/Footer.tsx
@@ -1,60 +1,56 @@
-import { GithubLogo, Rocket } from '@phosphor-icons/react'
+import { Anchor, GithubLogo } from '@phosphor-icons/react'
 
 const GITHUB_REPO = 'https://github.com/mattzcarey/shippie'
 const DOCS_URL = 'https://github.com/mattzcarey/shippie/tree/main/docs'
 const NPM_URL = 'https://www.npmjs.com/package/shippie'
 
+const links = [
+  { label: 'GitHub', href: GITHUB_REPO, external: true },
+  { label: 'Docs', href: DOCS_URL, external: true },
+  { label: 'npm', href: NPM_URL, external: true },
+  { label: 'FAQ', href: '#faq', external: false },
+]
+
 const Footer = () => {
   return (
-    <footer className="w-full border-t border-gray-200 dark:border-neutral-800">
-      <div className="container mx-auto">
-        <div className="flex flex-col gap-8 py-12 md:flex-row md:items-center md:justify-between">
+    <footer className="w-full border-t border-border">
+      <div className="container mx-auto px-6">
+        <div className="flex flex-col gap-8 py-14 md:flex-row md:items-start md:justify-between">
           <div className="flex flex-col gap-3">
             <a href="/" className="flex items-center gap-2">
-              <Rocket size={24} weight="fill" className="text-black dark:text-white" />
-              <span className="font-medium text-black dark:text-white">Shippie</span>
+              <Anchor size={20} weight="bold" className="text-signal" />
+              <span className="font-display text-xl font-extrabold uppercase tracking-tight">
+                Shippie
+              </span>
             </a>
             <p className="max-w-xs text-sm text-muted-foreground">
-              An extendable, open-source AI code review agent.
+              The AI reviewer that clears your code to merge.
             </p>
+            <span className="mt-2 font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground/55">
+              Manifest № SHP · open source
+            </span>
           </div>
 
-          <nav className="flex flex-wrap gap-x-8 gap-y-3 text-sm">
-            <a
-              href={GITHUB_REPO}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <GithubLogo size={16} weight="fill" /> GitHub
-            </a>
-            <a
-              href={DOCS_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-muted-foreground transition-colors hover:text-foreground"
-            >
-              Docs
-            </a>
-            <a
-              href={NPM_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-muted-foreground transition-colors hover:text-foreground"
-            >
-              npm
-            </a>
-            <a
-              href="#faq"
-              className="text-muted-foreground transition-colors hover:text-foreground"
-            >
-              FAQ
-            </a>
+          <nav className="flex flex-wrap gap-x-8 gap-y-3 font-mono text-xs uppercase tracking-[0.14em]">
+            {links.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                {...(link.external
+                  ? { target: '_blank', rel: 'noopener noreferrer' }
+                  : {})}
+                className="flex items-center gap-2 text-muted-foreground transition-colors hover:text-signal"
+              >
+                {link.label === 'GitHub' && <GithubLogo size={14} weight="fill" />}
+                {link.label}
+              </a>
+            ))}
           </nav>
         </div>
 
-        <div className="border-t border-gray-200 py-6 text-sm text-muted-foreground dark:border-neutral-800">
-          <p>© {new Date().getFullYear()} Shippie · Open source under the MIT license.</p>
+        <div className="flex items-center justify-between border-t border-border py-6 font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground/65">
+          <p>© {new Date().getFullYear()} Shippie</p>
+          <p>MIT license</p>
         </div>
       </div>
     </footer>

--- a/apps/www/src/components/Hero.tsx
+++ b/apps/www/src/components/Hero.tsx
@@ -1,8 +1,7 @@
-import { GithubLogo } from '@phosphor-icons/react'
+import { ArrowRight, GithubLogo, SealCheck } from '@phosphor-icons/react'
 import { motion } from 'framer-motion'
 import { useEffect, useMemo, useState } from 'react'
 import { ShellCommand } from './ShellCommand'
-import { Button } from './ui/button'
 
 const GITHUB_REPO = 'https://github.com/mattzcarey/shippie'
 
@@ -19,35 +18,63 @@ const Hero = () => {
   )
 
   useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      if (titleNumber === titles.length - 1) {
-        setTitleNumber(0)
-      } else {
-        setTitleNumber(titleNumber + 1)
-      }
-    }, 2000)
-    return () => clearTimeout(timeoutId)
-  }, [titleNumber, titles])
+    const id = setInterval(() => setTitleNumber((n) => (n + 1) % titles.length), 2200)
+    return () => clearInterval(id)
+  }, [titles])
 
   return (
-    <div className="w-full pt-14">
-      <div className="container mx-auto">
-        <div className="flex gap-8 py-20 pb-12 lg:py-32 lg:pb-16 items-center justify-center flex-col">
-          <div>
-            <Button variant="secondary" size="sm" className="gap-2" asChild>
-              <a href={GITHUB_REPO} target="_blank" rel="noopener noreferrer">
-                <GithubLogo size={16} weight="fill" /> Open source on GitHub
-              </a>
-            </Button>
-          </div>
-          <div className="flex gap-4 flex-col">
-            <h1 className="text-5xl md:text-7xl max-w-3xl tracking-tighter text-center font-regular">
-              <span className="bg-gradient-to-b from-white to-white/65 bg-clip-text font-semibold text-transparent">
+    <section className="relative w-full overflow-hidden">
+      <div className="container mx-auto px-6">
+        <div className="flex flex-col items-center pt-28 pb-20 text-center md:pt-36 lg:pb-28">
+          {/* manifest eyebrow */}
+          <motion.a
+            href={GITHUB_REPO}
+            target="_blank"
+            rel="noopener noreferrer"
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="group mb-9 inline-flex items-center gap-2.5 border border-border bg-card/40 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground backdrop-blur transition-colors hover:border-signal/40 hover:text-foreground"
+          >
+            <span className="text-signal">●</span>
+            Open source
+            <span className="text-border">/</span>
+            <GithubLogo size={13} weight="fill" />
+            mattzcarey/shippie
+            <ArrowRight
+              size={12}
+              className="transition-transform group-hover:translate-x-0.5"
+            />
+          </motion.a>
+
+          {/* headline + inspection stamp */}
+          <div className="relative">
+            <motion.div
+              initial={{ opacity: 0, scale: 1.5, rotate: -24 }}
+              animate={{ opacity: 1, scale: 1, rotate: -11 }}
+              transition={{ delay: 0.6, type: 'spring', stiffness: 130, damping: 11 }}
+              className="pointer-events-none absolute -top-12 right-0 hidden select-none md:block lg:-right-20"
+            >
+              <div className="flex items-center gap-2 border-2 border-signal/70 px-3 py-1.5 text-signal shadow-[inset_0_0_0_2px_rgba(255,74,28,0.18)]">
+                <SealCheck size={18} weight="bold" />
+                <span className="font-mono text-xs font-bold uppercase tracking-[0.18em]">
+                  Cleared to merge
+                </span>
+              </div>
+            </motion.div>
+
+            <motion.h1
+              initial={{ opacity: 0, y: 18 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1, duration: 0.6 }}
+              className="font-display text-[clamp(3.5rem,12vw,9rem)] font-extrabold uppercase leading-[0.84] tracking-tight"
+            >
+              <span className="block bg-gradient-to-b from-foreground to-foreground/55 bg-clip-text text-transparent">
                 AI code review
               </span>
-              <span className="mt-2 flex flex-wrap items-baseline justify-center gap-x-3 text-3xl text-muted-foreground md:text-5xl">
-                <span>on every</span>
-                <span className="relative inline-block whitespace-nowrap text-left font-semibold text-red-500">
+              <span className="mt-2 flex flex-wrap items-baseline justify-center gap-x-4 text-[clamp(1.9rem,7vw,5rem)] font-bold text-muted-foreground">
+                <span className="font-display uppercase">on every</span>
+                <span className="relative inline-block whitespace-nowrap text-left font-display uppercase text-signal">
                   {/* invisible sizer reserves the widest word's width + the baseline */}
                   <span className="invisible" aria-hidden="true">
                     {longestTitle}
@@ -56,12 +83,12 @@ const Hero = () => {
                     <motion.span
                       key={title}
                       className="absolute left-0 top-0 whitespace-nowrap"
-                      initial={{ opacity: 0, y: 40 }}
-                      transition={{ type: 'spring', stiffness: 50 }}
+                      initial={false}
+                      transition={{ type: 'spring', stiffness: 60, damping: 12 }}
                       animate={
                         titleNumber === index
                           ? { y: 0, opacity: 1 }
-                          : { y: titleNumber > index ? -40 : 40, opacity: 0 }
+                          : { y: titleNumber > index ? -30 : 30, opacity: 0 }
                       }
                     >
                       {title}
@@ -69,27 +96,36 @@ const Hero = () => {
                   ))}
                 </span>
               </span>
-            </h1>
-
-            <p className="mt-4 max-w-xl text-center text-lg leading-relaxed tracking-tight text-muted-foreground md:text-2xl">
-              Bugs, leaked secrets, missing tests — caught before they merge.
-            </p>
+            </motion.h1>
           </div>
 
-          <div className="mt-6 flex flex-col items-center gap-3 w-full max-w-xl">
-            <p className="text-muted-foreground text-center">
-              Add it to your repo in one command:
-            </p>
+          {/* subhead */}
+          <motion.p
+            initial={{ opacity: 0, y: 14 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.25, duration: 0.6 }}
+            className="mt-8 max-w-xl text-balance text-lg leading-relaxed text-muted-foreground md:text-xl"
+          >
+            Bugs, leaked secrets, missing tests —{' '}
+            <span className="text-foreground">caught before they merge.</span>
+          </motion.p>
+
+          {/* install command */}
+          <motion.div
+            initial={{ opacity: 0, y: 14 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.4, duration: 0.6 }}
+            className="mt-10 flex w-full max-w-xl flex-col items-center gap-3"
+          >
             <ShellCommand command="npx shippie init" />
-            <p className="text-sm text-muted-foreground text-center">
-              Scaffolds a GitHub Action that reviews every pull request. Or run{' '}
-              <code className="font-mono text-foreground">npx shippie review</code> to
-              review your staged changes locally.
+            <p className="font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground/70">
+              Scaffolds a GitHub Action · or{' '}
+              <span className="text-foreground/80">npx shippie review</span> locally
             </p>
-          </div>
+          </motion.div>
         </div>
       </div>
-    </div>
+    </section>
   )
 }
 

--- a/apps/www/src/components/Navbar.tsx
+++ b/apps/www/src/components/Navbar.tsx
@@ -169,7 +169,7 @@ const CustomNavbar = () => {
                 onClick={() => setIsMobileMenuOpen(false)}
                 className={`relative text-neutral-600 dark:text-neutral-300 ${
                   activeSection === item.link.substring(1)
-                    ? 'font-medium text-blue-600 dark:text-blue-400'
+                    ? 'font-medium text-signal'
                     : ''
                 }`}
               >

--- a/apps/www/src/components/ShellCommand.tsx
+++ b/apps/www/src/components/ShellCommand.tsx
@@ -15,28 +15,29 @@ const ShellCommand = ({ command }: ShellCommandProps) => {
   }
 
   return (
-    <div className="group relative w-full max-w-xl overflow-hidden rounded-xl border border-border bg-card/40 shadow-xl shadow-black/30 backdrop-blur">
-      {/* faint top highlight for a glassy terminal feel */}
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
+    <div className="group relative w-full max-w-xl border border-border bg-card/50 shadow-[0_24px_60px_-30px_rgba(0,0,0,0.9)] backdrop-blur">
+      {/* corner registration ticks */}
+      <span className="pointer-events-none absolute -left-px -top-px h-2 w-2 border-l-2 border-t-2 border-signal/60" />
+      <span className="pointer-events-none absolute -bottom-px -right-px h-2 w-2 border-b-2 border-r-2 border-signal/60" />
       <div className="flex items-center justify-between gap-3 px-5 py-4 font-mono text-sm">
         <div className="flex min-w-0 items-center gap-3">
-          <span className="select-none text-emerald-400">$</span>
+          <span className="select-none font-bold text-signal">$</span>
           <span className="truncate text-foreground/90">{command}</span>
         </div>
         <button
           type="button"
           onClick={copyToClipboard}
           aria-label="Copy command"
-          className="flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          className="flex shrink-0 items-center gap-1.5 border border-transparent px-2 py-1 text-[11px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:border-border hover:text-foreground"
         >
           {copied ? (
             <>
-              <Check size={14} weight="bold" className="text-emerald-400" />
+              <Check size={13} weight="bold" className="text-signal" />
               Copied
             </>
           ) : (
             <>
-              <Copy size={14} />
+              <Copy size={13} />
               Copy
             </>
           )}

--- a/apps/www/src/components/ui/resizable-navbar.tsx
+++ b/apps/www/src/components/ui/resizable-navbar.tsx
@@ -127,7 +127,7 @@ export const NavItems = ({
         <a
           onMouseEnter={() => setHovered(idx)}
           onClick={onItemClick}
-          className={`relative px-4 py-2 ${activeSection === item.link.substring(1) ? 'font-medium text-blue-600 dark:text-blue-400' : 'text-neutral-600 dark:text-neutral-300'}`}
+          className={`relative px-4 py-2 font-mono text-xs uppercase tracking-[0.12em] ${activeSection === item.link.substring(1) ? 'font-semibold text-signal' : 'text-muted-foreground hover:text-foreground'}`}
           key={item.link}
           href={item.link}
         >
@@ -234,12 +234,10 @@ export const NavbarButton = ({
     'px-4 py-2 rounded-md bg-white button bg-white text-black text-sm font-bold relative cursor-pointer hover:-translate-y-0.5 transition duration-200 inline-block text-center'
 
   const variantStyles = {
-    primary:
-      'shadow-[0_0_24px_rgba(34,_42,_53,_0.06),_0_1px_1px_rgba(0,_0,_0,_0.05),_0_0_0_1px_rgba(34,_42,_53,_0.04),_0_0_4px_rgba(34,_42,_53,_0.08),_0_16px_68px_rgba(47,_48,_55,_0.05),_0_1px_0_rgba(255,_255,_255,_0.1)_inset]',
-    secondary: 'bg-transparent shadow-none dark:text-white',
-    dark: 'bg-black text-white shadow-[0_0_24px_rgba(34,_42,_53,_0.06),_0_1px_1px_rgba(0,_0,_0,_0.05),_0_0_0_1px_rgba(34,_42,_53,_0.04),_0_0_4px_rgba(34,_42,_53,_0.08),_0_16px_68px_rgba(47,_48,_55,_0.05),_0_1px_0_rgba(255,_255,_255,_0.1)_inset]',
-    gradient:
-      'bg-gradient-to-b from-blue-500 to-blue-700 text-white shadow-[0px_2px_0px_0px_rgba(255,255,255,0.3)_inset]',
+    primary: 'bg-signal text-signal-foreground font-semibold hover:brightness-110',
+    secondary: 'bg-transparent shadow-none text-foreground',
+    dark: 'bg-black text-white',
+    gradient: 'bg-signal text-signal-foreground',
   }
 
   return (

--- a/apps/www/src/routes/_index.tsx
+++ b/apps/www/src/routes/_index.tsx
@@ -8,10 +8,11 @@ import CustomNavbar from '../components/Navbar'
 const IndexPage: React.FC = () => {
   return (
     <div className="relative min-h-screen overflow-x-hidden">
-      {/* ambient background: a soft red glow up top, a faint grid that fades out */}
+      {/* ambient background: vermilion signal glow + a blueprint grid that fades out */}
       <div aria-hidden="true" className="pointer-events-none fixed inset-0 -z-10">
-        <div className="absolute left-1/2 top-[-220px] h-[620px] w-[1000px] -translate-x-1/2 rounded-full bg-red-500/15 blur-[150px]" />
-        <div className="absolute inset-0 [background-image:linear-gradient(to_right,rgba(255,255,255,0.035)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.035)_1px,transparent_1px)] [background-size:64px_64px] [mask-image:radial-gradient(ellipse_at_top,black_10%,transparent_65%)]" />
+        <div className="absolute left-1/2 top-[-260px] h-[680px] w-[1100px] -translate-x-1/2 rounded-full bg-signal/12 blur-[160px]" />
+        <div className="absolute inset-0 [background-image:linear-gradient(to_right,rgba(236,230,218,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(236,230,218,0.05)_1px,transparent_1px)] [background-size:48px_48px] [mask-image:radial-gradient(ellipse_at_top,black_5%,transparent_60%)]" />
+        <div className="absolute inset-x-0 bottom-0 h-72 bg-gradient-to-t from-background to-transparent" />
       </div>
       <CustomNavbar />
       <Hero />

--- a/apps/www/src/styles.css
+++ b/apps/www/src/styles.css
@@ -3,11 +3,22 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* ─────────────────────────────────────────────────────────────
+   Shippie — "Freight Inspection"
+   Warm carbon ink · bone paper · one vermilion signal accent.
+   Display: Saira Condensed · Body: Archivo · Mono: JetBrains Mono
+   ───────────────────────────────────────────────────────────── */
+
 @theme inline {
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --font-display: "Saira Condensed", "Arial Narrow", sans-serif;
+  --font-sans: "Archivo", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, monospace;
+
+  --radius-sm: 2px;
+  --radius-md: 3px;
+  --radius-lg: 4px;
+  --radius-xl: 6px;
+
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -26,116 +37,131 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
+
+  /* the one hot accent */
+  --color-signal: var(--signal);
+  --color-signal-foreground: var(--signal-foreground);
+  --color-paper: var(--paper);
 }
 
-:root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.21 0.006 285.885);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.705 0.015 286.067);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.21 0.006 285.885);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.705 0.015 286.067);
-}
-
+:root,
 .dark {
-  --background: oklch(0.141 0.005 285.823);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.92 0.004 286.32);
-  --primary-foreground: oklch(0.21 0.006 285.885);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.552 0.016 285.938);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.274 0.006 286.033);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.552 0.016 285.938);
+  --radius: 3px;
+
+  --background: #0b0a08;
+  --foreground: #ece6da;
+  --card: #131210;
+  --card-foreground: #ece6da;
+  --popover: #131210;
+  --popover-foreground: #ece6da;
+  --primary: #ece6da;
+  --primary-foreground: #0b0a08;
+  --secondary: #1b1814;
+  --secondary-foreground: #ece6da;
+  --muted: #1b1814;
+  --muted-foreground: #948b7c;
+  --accent: #1b1814;
+  --accent-foreground: #ece6da;
+  --destructive: #ff4a1c;
+  --border: rgba(236, 230, 218, 0.1);
+  --input: rgba(236, 230, 218, 0.14);
+  --ring: #ff4a1c;
+
+  --signal: #ff4a1c;
+  --signal-foreground: #0b0a08;
+  --paper: #ece6da;
 }
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    @apply border-border;
   }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans antialiased;
+    font-feature-settings: "ss01", "cv01";
+  }
+
+  ::selection {
+    background: var(--signal);
+    color: var(--signal-foreground);
+  }
+
+  /* film grain — fixed full-bleed, drifts subtly */
+  body::before {
+    content: "";
+    position: fixed;
+    inset: -50%;
+    z-index: 50;
+    pointer-events: none;
+    opacity: 0.05;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    animation: grain 8s steps(6) infinite;
+  }
+
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: var(--background);
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--muted);
+    border: 2px solid var(--background);
+    border-radius: 0;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--signal);
   }
 }
 
-/* Add custom animation for the feature card */
-@keyframes move {
-  0% {
-    transform: translateY(-10px);
-    opacity: 0;
+@utility font-display {
+  font-family: var(--font-display);
+}
+
+/* Hairline registration marks for "manifest" cards */
+@utility reg-marks {
+  position: relative;
+}
+
+@keyframes grain {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  10% {
+    transform: translate(-5%, -5%);
+  }
+  30% {
+    transform: translate(3%, -8%);
   }
   50% {
-    opacity: 1;
+    transform: translate(-4%, 6%);
   }
-  100% {
-    transform: translateY(10px);
-    opacity: 0;
+  70% {
+    transform: translate(6%, 3%);
+  }
+  90% {
+    transform: translate(-3%, 4%);
   }
 }
 
-.animate-move {
-  animation: move 3s infinite;
+@keyframes marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.animate-marquee {
+  animation: marquee 28s linear infinite;
 }
 
 /* Add accordion animations */


### PR DESCRIPTION
A distinctive redesign of shippie.dev with a real point of view — replacing the generic shadcn-dark look.

## Concept: *Freight Inspection*
Code review is the inspection your code clears before it ships.

- **Palette:** warm carbon ink + bone paper + one hot **vermilion** signal accent (no more flat black / generic red).
- **Type:** **Saira Condensed** (transit-signage display) · **Archivo** (body) · **JetBrains Mono** (labels/tracking) — none of the AI-slop fonts.
- **Atmosphere:** film-grain overlay + a blueprint grid that fades out + a vermilion glow.
- **Hero:** huge condensed headline, a rotated **"CLEARED TO MERGE"** inspection stamp, staggered load motion, mono manifest eyebrow.
- **Features:** numbered "inspection report" cards (01/02/03, CI/AGENT/MCP tags, signal active-rail).
- **Details:** terminal command box with a signal `$` + registration corner-ticks; mono micro-labels; sharp 3px radii; custom selection + scrollbar.

## Verified
- biome (apps) clean · `tsc -b` · `vite build` green
- **Deployed to prod** — shippie.dev 200, fonts loading, www→apex redirect intact.

Note: the dark/light toggle is now effectively a no-op (the design is committed-dark); happy to remove it in a follow-up.