### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,13 @@ inputs:
   CLOUDFLARE_GATEWAY_ID:
     description: "Cloudflare AI Gateway ID (only for model 'cloudflare-ai-gateway/<model>')"
     required: false
+  LITELLM_API_KEY:
+    description: "LiteLLM proxy API key (master or virtual key)"
+    required: false
+  LITELLM_BASE_URL:
+    description: "LiteLLM proxy base URL, e.g. https://litellm.example.com"
+    required: false
+    default: "http://localhost:4000"
   TELEMETRY:
     description: "Send anonymous usage telemetry. Set to 'false' to opt out."
     required: false
@@ -87,6 +94,8 @@ runs:
         CLOUDFLARE_API_KEY: ${{ inputs.CLOUDFLARE_API_KEY || env.CLOUDFLARE_API_KEY }}
         CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID || env.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_GATEWAY_ID: ${{ inputs.CLOUDFLARE_GATEWAY_ID || env.CLOUDFLARE_GATEWAY_ID }}
+        LITELLM_API_KEY: ${{ inputs.LITELLM_API_KEY || env.LITELLM_API_KEY }}
+        LITELLM_BASE_URL: ${{ inputs.LITELLM_BASE_URL || env.LITELLM_BASE_URL }}
         # GitHub commenting + PR identity (read by resolveReviewConfig)
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN || env.GITHUB_TOKEN }}
         SHIPPIE_PR_NUMBER: ${{ inputs.PR_NUMBER || github.event.pull_request.number }}

--- a/docs/action-options.md
+++ b/docs/action-options.md
@@ -23,6 +23,8 @@ All inputs are optional except `GITHUB_TOKEN`.
 | `CLOUDFLARE_API_KEY` | Cloudflare API token (for `cloudflare-workers-ai/<model>` or `cloudflare-ai-gateway/<model>`). | No | — |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID (required for the Cloudflare Workers AI / AI Gateway providers). | No | — |
 | `CLOUDFLARE_GATEWAY_ID` | Cloudflare AI Gateway ID (only for `cloudflare-ai-gateway/<model>`). | No | — |
+| `LITELLM_API_KEY` | LiteLLM proxy API key (for `litellm/<model>`). | No | — |
+| `LITELLM_BASE_URL` | LiteLLM proxy base URL. | No | `http://localhost:4000` |
 | `GITHUB_TOKEN` | GitHub token used to post review comments. | **Yes** | — |
 
 Provide the provider credential that matches your chosen `MODEL`. For example, the

--- a/docs/ai-provider-config.md
+++ b/docs/ai-provider-config.md
@@ -19,6 +19,7 @@ cloudflare-workers-ai/@cf/openai/gpt-oss-120b
 | `openrouter`            | `OPENROUTER_API_KEY`                                         | `openrouter/anthropic/claude-sonnet-4-6`      |
 | `cloudflare-workers-ai` | `CLOUDFLARE_API_KEY` + `CLOUDFLARE_ACCOUNT_ID`              | `cloudflare-workers-ai/@cf/openai/gpt-oss-120b` |
 | `cloudflare-ai-gateway` | `CLOUDFLARE_API_KEY` + `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_GATEWAY_ID` | `cloudflare-ai-gateway/anthropic/claude-sonnet-4-6` |
+| `litellm`               | `LITELLM_API_KEY` + `LITELLM_BASE_URL`                               | `litellm/anthropic/claude-sonnet-4-6`             |
 
 ## Setting the model
 
@@ -90,6 +91,33 @@ call tools reliably.
 
 For a Cloudflare AI Gateway in front of these models, use the
 `cloudflare-ai-gateway` prefix and additionally set `CLOUDFLARE_GATEWAY_ID`.
+
+## LiteLLM (AI gateway)
+
+[LiteLLM](https://litellm.ai) is an AI gateway that lets you access 100+ LLM providers
+(OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Ollama, and more) through a single
+OpenAI-compatible endpoint. Run a LiteLLM proxy and point shippie at it:
+
+```bash
+export LITELLM_API_KEY=sk-...      # proxy master or virtual key
+export LITELLM_BASE_URL=http://localhost:4000
+SHIPPIE_MODEL=litellm/anthropic/claude-sonnet-4-6 npm run review
+```
+
+GitHub Action:
+
+```yaml
+- uses: mattzcarey/shippie@main
+  with:
+    MODEL: litellm/anthropic/claude-sonnet-4-6
+  env:
+    LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+    LITELLM_BASE_URL: https://litellm.example.com
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The model string after `litellm/` is passed directly to the proxy, so use whatever
+model identifiers your LiteLLM config defines.
 
 ## Custom OpenAI-compatible providers
 

--- a/docs/ai-provider-config.md
+++ b/docs/ai-provider-config.md
@@ -119,6 +119,16 @@ GitHub Action:
 The model string after `litellm/` is passed directly to the proxy, so use whatever
 model identifiers your LiteLLM config defines.
 
+**Important:** enable `drop_params: true` in your LiteLLM proxy config so that
+OpenAI-specific parameters (like `store`) are silently dropped for providers that
+don't support them:
+
+```yaml
+# litellm_config.yaml
+litellm_settings:
+  drop_params: true
+```
+
 ## Custom OpenAI-compatible providers
 
 To use a self-hosted or third-party OpenAI-compatible endpoint (for example Ollama or

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -121,5 +121,6 @@ Use a `provider/model` string and supply the matching credential:
 | `openrouter/<model>` | — | `OPENROUTER_API_KEY` |
 | `cloudflare-workers-ai/<model>` | `cloudflare-workers-ai/@cf/openai/gpt-oss-120b` | `CLOUDFLARE_API_KEY` + `CLOUDFLARE_ACCOUNT_ID` |
 | `cloudflare-ai-gateway/<model>` | — | `CLOUDFLARE_API_KEY` + `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_GATEWAY_ID` |
+| `litellm/<model>` | `litellm/anthropic/claude-sonnet-4-6` | `LITELLM_API_KEY` + `LITELLM_BASE_URL` |
 
-For Cloudflare Workers AI, prefer larger models with strong tool-calling (e.g. `@cf/openai/gpt-oss-120b`, `@cf/qwen/qwen3-30b-a3b-fp8`, `@cf/zai-org/glm-5.2`); small models like `@cf/meta/llama-3.3-70b` are weak at tool-calling. Custom OpenAI-compatible providers (Ollama, gateways) are registered with `registerProvider()` in `src/app.ts`.
+For Cloudflare Workers AI, prefer larger models with strong tool-calling (e.g. `@cf/openai/gpt-oss-120b`, `@cf/qwen/qwen3-30b-a3b-fp8`, `@cf/zai-org/glm-5.2`); small models like `@cf/meta/llama-3.3-70b` are weak at tool-calling. For LiteLLM, see [AI Provider Configuration](./ai-provider-config.md#litellm-ai-gateway). Custom OpenAI-compatible providers (Ollama, gateways) are registered with `registerProvider()` in `src/app.ts`.

--- a/src/agents/mention.ts
+++ b/src/agents/mention.ts
@@ -1,3 +1,4 @@
+import '../common/litellm'
 import { createAgent } from '@flue/runtime'
 import { channel, commentOnIssue, getPullRequestDiff } from '../channels/github'
 

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -1,3 +1,4 @@
+import '../common/litellm'
 import { createAgent } from '@flue/runtime'
 import { local } from '@flue/runtime/node'
 import { createReporter } from '../github/reporter'

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,12 @@
+import { registerProvider } from '@flue/runtime'
+
+const baseUrl = process.env.LITELLM_BASE_URL || 'http://localhost:4000'
+const apiKey = process.env.LITELLM_API_KEY
+
+if (apiKey) {
+  registerProvider('litellm', {
+    api: 'openai-completions',
+    baseUrl: baseUrl.replace(/\/+$/, '') + '/v1',
+    apiKey,
+  })
+}

--- a/src/common/litellm.ts
+++ b/src/common/litellm.ts
@@ -1,12 +1,20 @@
 import { registerProvider } from '@flue/runtime'
 
+function normalizeLitellmBaseUrl(raw: string): string {
+  let url = raw.replace(/\/+$/, '')
+  if (url.endsWith('/v1')) {
+    url = url.slice(0, -3)
+  }
+  return url + '/v1'
+}
+
 const baseUrl = process.env.LITELLM_BASE_URL || 'http://localhost:4000'
 const apiKey = process.env.LITELLM_API_KEY
 
 if (apiKey) {
   registerProvider('litellm', {
     api: 'openai-completions',
-    baseUrl: baseUrl.replace(/\/+$/, '') + '/v1',
+    baseUrl: normalizeLitellmBaseUrl(baseUrl),
     apiKey,
   })
 }

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('app.ts: LiteLLM provider registration', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of ['LITELLM_API_KEY', 'LITELLM_BASE_URL']) {
+      saved[key] = process.env[key]
+      delete process.env[key]
+    }
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    for (const key of ['LITELLM_API_KEY', 'LITELLM_BASE_URL']) {
+      if (saved[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = saved[key]
+      }
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('does not throw when LITELLM_API_KEY is unset', async () => {
+    await expect(import('../src/app')).resolves.toBeDefined()
+  })
+
+  it('calls registerProvider when LITELLM_API_KEY is set', async () => {
+    const mockRegister = vi.fn()
+    vi.doMock('@flue/runtime', () => ({ registerProvider: mockRegister }))
+
+    process.env.LITELLM_API_KEY = 'sk-test-key'
+    process.env.LITELLM_BASE_URL = 'https://litellm.example.com'
+
+    await import('../src/app')
+
+    expect(mockRegister).toHaveBeenCalledWith('litellm', {
+      api: 'openai-completions',
+      baseUrl: 'https://litellm.example.com/v1',
+      apiKey: 'sk-test-key',
+    })
+  })
+
+  it('defaults LITELLM_BASE_URL to localhost:4000', async () => {
+    const mockRegister = vi.fn()
+    vi.doMock('@flue/runtime', () => ({ registerProvider: mockRegister }))
+
+    process.env.LITELLM_API_KEY = 'sk-test-key'
+    delete process.env.LITELLM_BASE_URL
+
+    await import('../src/app')
+
+    expect(mockRegister).toHaveBeenCalledWith('litellm', {
+      api: 'openai-completions',
+      baseUrl: 'http://localhost:4000/v1',
+      apiKey: 'sk-test-key',
+    })
+  })
+
+  it('strips trailing slashes from base URL', async () => {
+    const mockRegister = vi.fn()
+    vi.doMock('@flue/runtime', () => ({ registerProvider: mockRegister }))
+
+    process.env.LITELLM_API_KEY = 'sk-test-key'
+    process.env.LITELLM_BASE_URL = 'https://litellm.example.com/'
+
+    await import('../src/app')
+
+    expect(mockRegister).toHaveBeenCalledWith('litellm', {
+      api: 'openai-completions',
+      baseUrl: 'https://litellm.example.com/v1',
+      apiKey: 'sk-test-key',
+    })
+  })
+})

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-describe('app.ts: LiteLLM provider registration', () => {
+describe('common/litellm.ts: LiteLLM provider registration', () => {
   const saved: Record<string, string | undefined> = {}
 
   beforeEach(() => {
@@ -22,18 +22,23 @@ describe('app.ts: LiteLLM provider registration', () => {
     vi.restoreAllMocks()
   })
 
-  it('does not throw when LITELLM_API_KEY is unset', async () => {
-    await expect(import('../src/app')).resolves.toBeDefined()
+  it('does not call registerProvider when LITELLM_API_KEY is unset', async () => {
+    const mockRegister = vi.fn()
+    vi.doMock('@flue/runtime', () => ({ registerProvider: mockRegister }))
+
+    await import('../src/common/litellm')
+
+    expect(mockRegister).not.toHaveBeenCalled()
   })
 
-  it('calls registerProvider when LITELLM_API_KEY is set', async () => {
+  it('registers with openai-completions API when key is set', async () => {
     const mockRegister = vi.fn()
     vi.doMock('@flue/runtime', () => ({ registerProvider: mockRegister }))
 
     process.env.LITELLM_API_KEY = 'sk-test-key'
     process.env.LITELLM_BASE_URL = 'https://litellm.example.com'
 
-    await import('../src/app')
+    await import('../src/common/litellm')
 
     expect(mockRegister).toHaveBeenCalledWith('litellm', {
       api: 'openai-completions',
@@ -49,7 +54,7 @@ describe('app.ts: LiteLLM provider registration', () => {
     process.env.LITELLM_API_KEY = 'sk-test-key'
     delete process.env.LITELLM_BASE_URL
 
-    await import('../src/app')
+    await import('../src/common/litellm')
 
     expect(mockRegister).toHaveBeenCalledWith('litellm', {
       api: 'openai-completions',
@@ -65,12 +70,55 @@ describe('app.ts: LiteLLM provider registration', () => {
     process.env.LITELLM_API_KEY = 'sk-test-key'
     process.env.LITELLM_BASE_URL = 'https://litellm.example.com/'
 
-    await import('../src/app')
+    await import('../src/common/litellm')
 
     expect(mockRegister).toHaveBeenCalledWith('litellm', {
       api: 'openai-completions',
       baseUrl: 'https://litellm.example.com/v1',
       apiKey: 'sk-test-key',
     })
+  })
+
+  it('does not double /v1 when user includes it in base URL', async () => {
+    const mockRegister = vi.fn()
+    vi.doMock('@flue/runtime', () => ({ registerProvider: mockRegister }))
+
+    process.env.LITELLM_API_KEY = 'sk-test-key'
+    process.env.LITELLM_BASE_URL = 'https://litellm.example.com/v1'
+
+    await import('../src/common/litellm')
+
+    expect(mockRegister).toHaveBeenCalledWith('litellm', {
+      api: 'openai-completions',
+      baseUrl: 'https://litellm.example.com/v1',
+      apiKey: 'sk-test-key',
+    })
+  })
+
+  it('handles /v1/ with trailing slash', async () => {
+    const mockRegister = vi.fn()
+    vi.doMock('@flue/runtime', () => ({ registerProvider: mockRegister }))
+
+    process.env.LITELLM_API_KEY = 'sk-test-key'
+    process.env.LITELLM_BASE_URL = 'https://litellm.example.com/v1/'
+
+    await import('../src/common/litellm')
+
+    expect(mockRegister).toHaveBeenCalledWith('litellm', {
+      api: 'openai-completions',
+      baseUrl: 'https://litellm.example.com/v1',
+      apiKey: 'sk-test-key',
+    })
+  })
+
+  it('does not register when API key is empty string', async () => {
+    const mockRegister = vi.fn()
+    vi.doMock('@flue/runtime', () => ({ registerProvider: mockRegister }))
+
+    process.env.LITELLM_API_KEY = ''
+
+    await import('../src/common/litellm')
+
+    expect(mockRegister).not.toHaveBeenCalled()
   })
 })

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -68,6 +68,10 @@ describe('smoke: modules load without crashing when secrets are absent', () => {
   it('imports the mention agent without throwing', async () => {
     await expect(import('../src/agents/mention')).resolves.toBeDefined()
   })
+
+  it('imports app.ts without throwing (litellm key unset)', async () => {
+    await expect(import('../src/app')).resolves.toBeDefined()
+  })
 })
 
 describe('smoke: review workflow public surface', () => {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -69,8 +69,8 @@ describe('smoke: modules load without crashing when secrets are absent', () => {
     await expect(import('../src/agents/mention')).resolves.toBeDefined()
   })
 
-  it('imports app.ts without throwing (litellm key unset)', async () => {
-    await expect(import('../src/app')).resolves.toBeDefined()
+  it('imports common/litellm.ts without throwing (litellm key unset)', async () => {
+    await expect(import('../src/common/litellm')).resolves.toBeDefined()
   })
 })
 


### PR DESCRIPTION
## Summary

Add [LiteLLM](https://litellm.ai) as a built-in AI gateway provider. Users point shippie at a LiteLLM proxy to access 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Ollama, and more) through one endpoint.


## Changes

- `src/common/litellm.ts` - Register `litellm` provider via `registerProvider()` (conditional on `LITELLM_API_KEY`)
- `src/agents/reviewer.ts` - Side-effect import of litellm registration
- `src/agents/mention.ts` - Side-effect import of litellm registration
- `action.yml` - Pass through `LITELLM_API_KEY` and `LITELLM_BASE_URL` inputs/env
- `docs/ai-provider-config.md` - LiteLLM section with usage examples + `drop_params` guidance
- `docs/action-options.md` - New inputs in the reference table
- `docs/setup.md` - LiteLLM row in the providers table
- `tests/app.test.ts` - 7 unit tests covering registration, URL normalization, edge cases
- `tests/smoke.test.ts` - Load-time crash guard

## How it works

LiteLLM exposes an OpenAI-compatible API, so flue's `openai-completions` wire protocol handles it natively. `src/common/litellm.ts` conditionally registers the provider when `LITELLM_API_KEY` is set:

```ts
registerProvider('litellm', {
  api: 'openai-completions',
  baseUrl: normalizeLitellmBaseUrl(baseUrl),
  apiKey,
})
```

The registration runs as a side-effect import from both agent modules (reviewer + mention), ensuring the provider is available before flue resolves the model specifier.

## Integration bug found and fixed

**URL double `/v1`:** If a user sets `LITELLM_BASE_URL=http://localhost:4000/v1`, the original code appended another `/v1`, producing `http://localhost:4000/v1/v1`. Fixed with `normalizeLitellmBaseUrl()` that strips a trailing `/v1` before re-adding it.

**`app.ts` default export:** Initial implementation used `src/app.ts`, but flue expects `app.ts` to export a Hono app (not side-effects). Moved registration to `src/common/litellm.ts` imported as a side-effect from the agent modules.

## Tests

**1. Unit tests (81/81 pass):**
```
 ✓ tests/app.test.ts (7 tests) 28ms
   - does not call registerProvider when LITELLM_API_KEY is unset
   - registers with openai-completions API when key is set
   - defaults LITELLM_BASE_URL to localhost:4000
   - strips trailing slashes from base URL
   - does not double /v1 when user includes it in base URL
   - handles /v1/ with trailing slash
   - does not register when API key is empty string
 ✓ tests/smoke.test.ts (7 tests) - includes litellm.ts load-time guard
```

**2. Lint + types:** `oxlint && oxfmt --check` clean, `tsc --noEmit` clean.

**3. Live E2E against a real provider (Claude Sonnet via Azure Foundry through LiteLLM proxy):**
```
$ LITELLM_API_KEY=test-key LITELLM_BASE_URL=http://localhost:4111 \
  SHIPPIE_MODEL=litellm/anthropic/claude-sonnet-4-6 \
  npx flue run review --target node --payload '{"platform":"local"}'

    run       run_01KVZ19WCZX6GY74HQDMTWVVDD
  I'll investigate the repository structure and context before posting comments.
tool read  test-review.js
tool suggest_change
tool done suggest_change
  **PR Summary** ... **Secret leak (highest severity):** The string
  `sk-live-abc123secret` follows the prefix pattern of real API keys ...
  **Recommendation:** Remove this file from the PR.
{
  "reviewed": 1,
  "summaryPosted": true,
  "summaryUrl": ".shippie/review/local_2026-06-25T09-20-45.976Z.md"
}
done workflow completed
```

Full chain verified: `litellm/anthropic/claude-sonnet-4-6` -> flue resolveModel -> openai-completions -> LiteLLM proxy (localhost:4111) -> Azure Foundry -> Claude Sonnet 4.6 -> response parsed -> inline `suggest_change` comment posted + PR summary written.

**4. Proxy `drop_params` note:** flue's openai-completions wire sends `store: false` (an OpenAI-specific param). Non-OpenAI providers reject it. Users must enable `drop_params: true` in their LiteLLM proxy config. Documented in the provider docs.

## Risk / Compatibility

- Additive only. No existing providers modified.
- No new dependencies. Uses flue's built-in `registerProvider()` + `openai-completions` API.
- Registration is conditional - `src/common/litellm.ts` is a no-op when `LITELLM_API_KEY` is unset.

## Example usage

```yaml
# GitHub Action
- uses: mattzcarey/shippie@main
  with:
    MODEL: litellm/anthropic/claude-sonnet-4-6
  env:
    LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
    LITELLM_BASE_URL: https://litellm.example.com
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

```bash
# Local
export LITELLM_API_KEY=sk-...
export LITELLM_BASE_URL=http://localhost:4000
SHIPPIE_MODEL=litellm/anthropic/claude-sonnet-4-6 npm run review
```
